### PR TITLE
ErrorBoundary 처리, CRLF / LF 충돌 문제 해결 , 무한 retry 문제 일부 완화

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["next/core-web-vitals", "airbnb", "airbnb-typescript"],
+  "extends": ["next/core-web-vitals", "airbnb", "airbnb-typescript", "plugin:prettier/recommended"],
   "parserOptions": {
     "project": "./tsconfig.json"
   },
@@ -10,6 +10,12 @@
     // Support for defaultProps will be removed from function components in a future major release. 
     // Use JavaScript default parameters instead. 로 인해 default-props 를 off 로 설정
     "react/require-default-props": "off",
-    "quotes": ["error", "single"]
+    "quotes": ["error", "single"],
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "next": "14.1.4",
     "react": "^18",
     "react-dom": "^18",
+    "react-error-boundary": "^4.0.13",
     "react-hot-toast": "^2.4.1",
     "react-intersection-observer": "^9.10.2",
     "react-share": "^5.1.0",

--- a/src/app/(chat)/_components/organisms/AgoraUserSuspense.tsx
+++ b/src/app/(chat)/_components/organisms/AgoraUserSuspense.tsx
@@ -5,6 +5,13 @@ import { useQuery } from '@tanstack/react-query';
 import { AgoraUser } from '@/app/model/AgoraUser';
 import AgoraUserList from '../molecules/AgoraUserList';
 import { getAgoraUsers } from '../../_lib/getAgoraUsers';
+import { ErrorBoundary } from 'react-error-boundary';
+import ErrorFallback from '@/app/_components/templates/ErrorFallback';
+
+const errorFallbackProps = {
+  headerLabel: '참여자 목록 오류',
+  btnLabel: '다시 불러오기',
+}
 
 type Props = {
   agoraId: number;
@@ -20,11 +27,11 @@ export default function AgoraUserSuspense({ agoraId }: Props) {
   return (
     <div>
       { userList && (
-        <>
+        <ErrorBoundary FallbackComponent={(props) => <ErrorFallback {...props} {...errorFallbackProps}/>}>
           <AgoraUserList position="PROS" userList={userList} />
           <div className="border-b-1 border-gray-200 mb-1rem dark:border-gray-500" />
           <AgoraUserList position="CONS" userList={userList} />
-        </>
+        </ErrorBoundary>
       )}
     </div>
   );

--- a/src/app/(chat)/_components/organisms/ErrorBoundaryMessage.tsx
+++ b/src/app/(chat)/_components/organisms/ErrorBoundaryMessage.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { ErrorBoundary } from 'react-error-boundary';
+import ErrorFallback from '@/app/_components/templates/ErrorFallback';
+import Message from "../molecules/Message";
+
+const errorFallbackProps = {
+    headerLabel: '채팅 불러오기 오류',
+    btnLabel: '다시 불러오기',
+  }
+
+export default function ErrorBoundaryMessage() {
+    return (
+    <ErrorBoundary FallbackComponent={(props) => <ErrorFallback {...props} {...errorFallbackProps}/>}>
+        <Message />
+    </ErrorBoundary>
+    )
+}

--- a/src/app/(chat)/agoras/[agora]/page.tsx
+++ b/src/app/(chat)/agoras/[agora]/page.tsx
@@ -1,7 +1,10 @@
-import Message from '@/app/(chat)/_components/molecules/Message';
 import fetchWrapper from '@/lib/fetchWrapper';
 import { headers } from 'next/headers';
 import React from 'react';
+import ErrorBoundaryMessage from '../../_components/organisms/ErrorBoundaryMessage';
+
+
+
 
 export async function generateMetadata() {
   const agoraId = headers().get('x-pathname')?.split('/').pop();
@@ -43,13 +46,14 @@ export async function generateMetadata() {
   };
 }
 
+
 export default function Page() {
   return (
     <main
       aria-label="채팅"
       className="flex flex-col justify-between h-full items-stretch"
     >
-      <Message />
+      <ErrorBoundaryMessage/>
     </main>
   );
 }

--- a/src/app/(main)/_components/organisms/SearchDeciderSuspense.tsx
+++ b/src/app/(main)/_components/organisms/SearchDeciderSuspense.tsx
@@ -1,11 +1,21 @@
+'use client';
+
 import { HydrationBoundary, QueryClient, dehydrate } from '@tanstack/react-query';
 import React from 'react';
 import { getAgoraCategorySearch } from '../../_lib/getAgoraCategorySearch';
 import SearchDecider from '../molecules/SearchDecider';
+import { ErrorBoundary } from 'react-error-boundary';
+import ErrorFallback from '@/app/_components/templates/ErrorFallback';
 
 type Props = {
   searchParams: { status?: string, category?: string, q?: string },
 };
+
+
+const errorFallbackProps = {
+  headerLabel: '아고라 목록을 불러오던 중 오류가 발생했습니다.',
+  btnLabel: '다시 불러오기',
+}
 
 export default async function SearchDeciderSuspense({ searchParams }: Props) {
   const queryClient = new QueryClient();
@@ -16,9 +26,12 @@ export default async function SearchDeciderSuspense({ searchParams }: Props) {
   });
   const dehydratedState = dehydrate(queryClient);
 
+  
   return (
-    <HydrationBoundary state={dehydratedState}>
-      <SearchDecider searchParams={searchParams} />
-    </HydrationBoundary>
+    <ErrorBoundary FallbackComponent={(props) => <ErrorFallback {...props} {...errorFallbackProps}/>}>
+      <HydrationBoundary state={dehydratedState}>
+        <SearchDecider searchParams={searchParams} />
+      </HydrationBoundary>
+    </ErrorBoundary>
   );
 }

--- a/src/app/_components/templates/ErrorFallback.tsx
+++ b/src/app/_components/templates/ErrorFallback.tsx
@@ -1,0 +1,21 @@
+import { FallbackProps } from 'react-error-boundary';
+
+type ErrorFallbackProps = FallbackProps & { headerLabel : string, btnLabel: string};
+
+export default function ErrorFallback({error, resetErrorBoundary, headerLabel, btnLabel} : ErrorFallbackProps){
+    return(
+        <div className="flex-col">
+            <p className="dark:text-white text-sm mt-12 text-center">{headerLabel}</p>
+            <div className="w-full flex justify-center">
+                <button className="bg-athens-main text-white rounded-full px-16 py-7 mt-20 text-sm justify-center items-center" 
+                        type="button"
+                        onClick={resetErrorBoundary}>
+                    {btnLabel}
+                </button>
+            </div>
+        </div>
+    )
+} 
+
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1782,21 +1782,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.3.1":
+  version: 7.24.7
+  resolution: "@babel/runtime@npm:7.24.7"
+  dependencies:
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 10c0/b6fa3ec61a53402f3c1d75f4d808f48b35e0dfae0ec8e2bb5c6fc79fb95935da75766e0ca534d0f1c84871f6ae0d2ebdd950727cfadb745a2cdbef13faef5513
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.8.4":
   version: 7.24.4
   resolution: "@babel/runtime@npm:7.24.4"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
   checksum: 10c0/785aff96a3aa8ff97f90958e1e8a7b1d47f793b204b47c6455eaadc3f694f48c97cd5c0a921fe3596d818e71f18106610a164fb0f1c71fd68c622a58269d537c
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.3.1":
-  version: 7.24.7
-  resolution: "@babel/runtime@npm:7.24.7"
-  dependencies:
-    regenerator-runtime: "npm:^0.14.0"
-  checksum: 10c0/b6fa3ec61a53402f3c1d75f4d808f48b35e0dfae0ec8e2bb5c6fc79fb95935da75766e0ca534d0f1c84871f6ae0d2ebdd950727cfadb745a2cdbef13faef5513
   languageName: node
   linkType: hard
 
@@ -3728,6 +3728,7 @@ __metadata:
     prettier: "npm:^3.2.5"
     react: "npm:^18"
     react-dom: "npm:^18"
+    react-error-boundary: "npm:^4.0.13"
     react-hot-toast: "npm:^2.4.1"
     react-intersection-observer: "npm:^9.10.2"
     react-share: "npm:^5.1.0"
@@ -8172,6 +8173,17 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
   checksum: 10c0/66dfc5f93e13d0674e78ef41f92ed21dfb80f9c4ac4ac25a4b51046d41d4d2186abc915b897f69d3d0ebbffe6184e7c5876f2af26bfa956f179225d921be713a
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^4.0.13":
+  version: 4.0.13
+  resolution: "react-error-boundary@npm:4.0.13"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: 10c0/6f3e0e4d7669f680ccf49c08c9571519c6e31f04dcfc30a765a7136c7e6fbbbe93423dd5a9fce12107f8166e54133e9dd5c2079a00c7a38201ac811f7a28b8e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 개발 사항
- ErrorBoundary 처리를 '아고라 목록 불러오기', '채팅 내역 불러오기' , '채팅방 인원 목록 불러오기' 페이지에 적용
- Windows 환경에서 발생하는 CRLF / LF 충돌문제 ESlint 설정을 통해 해결. 
- 잘못된 API에 요청할 시, 무한 retry 문제 일부 완화. (여전히 의도한대로 동작하지 않기에 추후 수정)