### PR TITLE
Fix : ErrorBoundary 래핑시 렌더링 중 컴포넌트 정의 문제 해결

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
       {
         "endOfLine": "auto"
       }
-    ]
+    ],
+    "react/jsx-props-no-spreading": "off"
   }
 }

--- a/src/app/(main)/_components/molecules/SearchDecider.tsx
+++ b/src/app/(main)/_components/molecules/SearchDecider.tsx
@@ -2,29 +2,43 @@
 
 import React, { Suspense } from 'react';
 import dynamic from 'next/dynamic';
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+import ErrorFallback from '@/app/_components/templates/ErrorFallback';
 import Loading from '../atoms/loading';
 
 const SearchAgoraList = dynamic(() => import('./SearchAgoraList'));
 const AgoraList = dynamic(() => import('./AgoraList'));
 
 type Props = {
-  searchParams: { status?: string, category?: string, q?: string }
+  searchParams: { status?: string; category?: string; q?: string };
 };
 
+const errorFallbackProps = {
+  headerLabel: '아고라 목록을 불러오던 중 오류가 발생했습니다.',
+  btnLabel: '다시 불러오기',
+};
+
+function FallbackComponent(props: FallbackProps) {
+  return <ErrorFallback {...props} {...errorFallbackProps} />;
+}
 export default function SearchDecider({ searchParams }: Props) {
   const { q } = searchParams;
 
   if (q) {
     return (
-      <Suspense fallback={<Loading />}>
-        <SearchAgoraList searchParams={searchParams} />
-      </Suspense>
+      <ErrorBoundary FallbackComponent={FallbackComponent}>
+        <Suspense fallback={<Loading />}>
+          <SearchAgoraList searchParams={searchParams} />
+        </Suspense>
+      </ErrorBoundary>
     );
   }
 
   return (
-    <Suspense fallback={<Loading />}>
-      <AgoraList searchParams={searchParams} />
-    </Suspense>
+    <ErrorBoundary FallbackComponent={FallbackComponent}>
+      <Suspense fallback={<Loading />}>
+        <AgoraList searchParams={searchParams} />
+      </Suspense>
+    </ErrorBoundary>
   );
 }

--- a/src/app/(main)/_components/organisms/SearchDeciderSuspense.tsx
+++ b/src/app/(main)/_components/organisms/SearchDeciderSuspense.tsx
@@ -1,21 +1,15 @@
-'use client';
-
-import { HydrationBoundary, QueryClient, dehydrate } from '@tanstack/react-query';
+import {
+  HydrationBoundary,
+  QueryClient,
+  dehydrate,
+} from '@tanstack/react-query';
 import React from 'react';
 import { getAgoraCategorySearch } from '../../_lib/getAgoraCategorySearch';
 import SearchDecider from '../molecules/SearchDecider';
-import { ErrorBoundary } from 'react-error-boundary';
-import ErrorFallback from '@/app/_components/templates/ErrorFallback';
 
 type Props = {
-  searchParams: { status?: string, category?: string, q?: string },
+  searchParams: { status?: string; category?: string; q?: string };
 };
-
-
-const errorFallbackProps = {
-  headerLabel: '아고라 목록을 불러오던 중 오류가 발생했습니다.',
-  btnLabel: '다시 불러오기',
-}
 
 export default async function SearchDeciderSuspense({ searchParams }: Props) {
   const queryClient = new QueryClient();
@@ -26,12 +20,9 @@ export default async function SearchDeciderSuspense({ searchParams }: Props) {
   });
   const dehydratedState = dehydrate(queryClient);
 
-  
   return (
-    <ErrorBoundary FallbackComponent={(props) => <ErrorFallback {...props} {...errorFallbackProps}/>}>
-      <HydrationBoundary state={dehydratedState}>
-        <SearchDecider searchParams={searchParams} />
-      </HydrationBoundary>
-    </ErrorBoundary>
+    <HydrationBoundary state={dehydratedState}>
+      <SearchDecider searchParams={searchParams} />
+    </HydrationBoundary>
   );
 }


### PR DESCRIPTION
## 개발 사항
- HydrationBoundary 하위에 ErrorBoundary 처리
- 렌더링 중 컴포넌트 정의를 피하기 위해 미리 컴포넌트를 정의한 뒤 사용함.