### PR TITLE
종료된 아고라 소켓 미연결 및 필요없는 정보 미출력

### DIFF
--- a/src/app/(chat)/_components/atoms/ChatNotification.tsx
+++ b/src/app/(chat)/_components/atoms/ChatNotification.tsx
@@ -1,36 +1,39 @@
 'use client';
 
-import { useChatInfo } from '@/store/chatInfo';
+import { useAgora } from '@/store/agora';
 import React, { useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
 export default function ChatNotification() {
   const [showMessage, setShowMessage] = useState(false);
-  const { end } = useChatInfo(useShallow((state) => ({
-    end: state.end,
-  })));
+  const { enterAgora } = useAgora(
+    useShallow((state) => ({
+      enterAgora: state.enterAgora,
+    })),
+  );
 
   useEffect(() => {
-    if (end) return () => {};
+    if (enterAgora.status !== 'CLOSED') return () => {};
     const timer = setTimeout(() => {
       setShowMessage(true);
     }, 10000);
 
     return () => clearTimeout(timer);
-  }, [end]);
+  }, [enterAgora.status]);
 
   return (
-    !showMessage && !end && (
-    <div className="flex p-0.5rem pl-1rem pr-1rem">
-      <div
-        role="alert"
-        aria-live="polite"
-        className="rounded-lg text-center flex flex-col justify-center items-center text-xs lg:text-sm under-mobile:text-xs text-athens-gray-thick p-11 bg-athens-gray dark:bg-dark-light-200 dark:text-dark-line w-full break-keep"
-      >
-        사용자들간의 쾌적한 토론 환경을 위해 바른말을 사용해주세요.
-        <div>토론을 시작하려면 상단의 START 버튼을 눌러주세요.</div>
+    !showMessage &&
+    !enterAgora.status && (
+      <div className="flex p-0.5rem pl-1rem pr-1rem">
+        <div
+          role="alert"
+          aria-live="polite"
+          className="rounded-lg text-center flex flex-col justify-center items-center text-xs lg:text-sm under-mobile:text-xs text-athens-gray-thick p-11 bg-athens-gray dark:bg-dark-light-200 dark:text-dark-line w-full break-keep"
+        >
+          사용자들간의 쾌적한 토론 환경을 위해 바른말을 사용해주세요.
+          <div>토론을 시작하려면 상단의 START 버튼을 눌러주세요.</div>
+        </div>
       </div>
-    </div>
     )
   );
 }

--- a/src/app/(chat)/_components/atoms/SocialShareLogos.tsx
+++ b/src/app/(chat)/_components/atoms/SocialShareLogos.tsx
@@ -28,7 +28,8 @@ type Props = {
 
 export default function SocialShareLogos({ title, url }: Props) {
   const pathname = useParams();
-  const sendUrl = url || `${process.env.NEXT_PUBLIC_CLIENT_URL}/agoras/${pathname.agora}`; // 공유할 URL
+  const sendUrl =
+    url || `${process.env.NEXT_PUBLIC_CLIENT_URL}/agoras/${pathname.agora}`; // 공유할 URL
 
   useEffect(() => {
     const swiper = new Swiper('.swiper', {
@@ -105,7 +106,9 @@ export default function SocialShareLogos({ title, url }: Props) {
               aria-label="페이스북으로 공유하기"
             >
               <FacebookIcon size={45} round />
-              <div className="text-xs pt-5 text-white">Facebook</div>
+              <div className="text-xs pt-5 text-white lg:text-black lg:dark:text-white">
+                Facebook
+              </div>
             </FacebookShareButton>
           </div>
           <div className="swiper-slide">
@@ -116,7 +119,9 @@ export default function SocialShareLogos({ title, url }: Props) {
               aria-label="페이스북 메신저로 공유하기"
             >
               <FacebookMessengerIcon size={45} round />
-              <div className="text-xs pt-5 text-white">Messanger</div>
+              <div className="text-xs pt-5 text-white lg:text-black lg:dark:text-white">
+                Messanger
+              </div>
             </FacebookMessengerShareButton>
           </div>
           <div className="swiper-slide">
@@ -127,13 +132,27 @@ export default function SocialShareLogos({ title, url }: Props) {
               aria-label="트위터로 공유하기"
             >
               <XIcon size={45} round />
-              <div className="text-xs pt-5 text-white">X</div>
+              <div className="text-xs pt-5 text-white lg:text-black lg:dark:text-white">
+                X
+              </div>
             </TwitterShareButton>
           </div>
           <div className="swiper-slide">
-            <button aria-label="카카오톡으로 공유하기" type="button" className="mr-20 flex flex-col justify-center items-center" onClick={shareKakao}>
-              <Image src="/img/kakao_logo.png" alt="카카오톡 로고" width={45} height={45} />
-              <div className="text-xs pt-5 text-white">Kakao Talk</div>
+            <button
+              aria-label="카카오톡으로 공유하기"
+              type="button"
+              className="mr-20 flex flex-col justify-center items-center"
+              onClick={shareKakao}
+            >
+              <Image
+                src="/img/kakao_logo.png"
+                alt="카카오톡 로고"
+                width={45}
+                height={45}
+              />
+              <div className="text-xs pt-5 text-white lg:text-black lg:dark:text-white">
+                Kakao Talk
+              </div>
             </button>
           </div>
           <div className="swiper-slide">
@@ -145,7 +164,9 @@ export default function SocialShareLogos({ title, url }: Props) {
               aria-label="이메일로 공유하기"
             >
               <EmailIcon size={45} round />
-              <div className="text-xs pt-5 text-white">Email</div>
+              <div className="text-xs pt-5 text-white lg:text-black lg:dark:text-white">
+                Email
+              </div>
             </EmailShareButton>
           </div>
           <div className="swiper-slide">
@@ -156,7 +177,9 @@ export default function SocialShareLogos({ title, url }: Props) {
               aria-label="라인으로 공유하기"
             >
               <LineIcon size={45} round />
-              <div className="text-xs pt-5 text-white">Line</div>
+              <div className="text-xs pt-5 text-white lg:text-black lg:dark:text-white">
+                Line
+              </div>
             </LineShareButton>
           </div>
         </div>

--- a/src/app/(chat)/_components/molecules/AgoraTitle.tsx
+++ b/src/app/(chat)/_components/molecules/AgoraTitle.tsx
@@ -5,9 +5,10 @@ type Props = {
   title: string;
   pros?: number;
   cons?: number;
+  isClosed?: boolean;
 };
 
-export default function AgoraTitle({ title, pros, cons }: Props) {
+export default function AgoraTitle({ title, pros, cons, isClosed }: Props) {
   return (
     <section className="flex flex-col justify-center items-center w-full dark:bg-dark-light-300 pb-5">
       <h1
@@ -20,22 +21,20 @@ export default function AgoraTitle({ title, pros, cons }: Props) {
         />
         {title}
       </h1>
-      <div
-        role="status"
-        aria-label="현재 참여 인원"
-        className="flex justify-around items-center w-full text-xs lg:text-sm under-mobile:text-xxs p-6 pt-0"
-      >
-        <div className="text-blue-600 dark:text-dark-pro-color">
-          찬성
-          {' '}
-          {pros}
+      {!isClosed && (
+        <div
+          role="status"
+          aria-label="현재 참여 인원"
+          className="flex justify-around items-center w-full text-xs lg:text-sm under-mobile:text-xxs p-6 pt-0"
+        >
+          <div className="text-blue-600 dark:text-dark-pro-color">
+            찬성 {pros}
+          </div>
+          <div className="text-red-600 dark:text-dark-con-color">
+            반대 {cons}
+          </div>
         </div>
-        <div className="text-red-600 dark:text-dark-con-color">
-          반대
-          {' '}
-          {cons}
-        </div>
-      </div>
+      )}
     </section>
   );
 }

--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -92,21 +92,14 @@ export default function Header() {
       // console.log('Disconnected');
     };
 
-    const getMetadata = () => {
-      if (client.current) {
-        client.current?.publish({
-          destination: `/app/agoras/${agoraId}`,
-        });
-      }
-    };
-
     const subscribe = () => {
-      // console.log('Subscribing... metadata');
-      getMetadata();
+      // getMetadata();
+      // console.log('Subscribing...');
       client.current?.subscribe(
-        `/topic/agoras/${agoraId}`,
+        `/topic/agoras/${agoraId}/meta`,
         (received_message: StompJs.IFrame) => {
           const data = JSON.parse(received_message.body);
+          // console.log('received_message', received_message);
           if (data.type === 'META') {
             setTitle(data.data.agora.title);
             setAgoraId(data.data.agora.id);
@@ -195,21 +188,24 @@ export default function Header() {
           subscribe();
         },
         onWebSocketError: async () => {
-          // showToast('네트워크가 불안정합니다.', 'error');
+          showToast('네트워크가 불안정합니다.', 'error');
           await getReissuanceToken();
-          // connect();
           // router.replace('/home');
         },
         onStompError: async () => {
+          showToast('서버 연결이 불안정합니다.', 'error');
           await getReissuanceToken();
-          connect();
         },
       });
       // console.log('Activating... metadata');
       client.current.activate();
     }
 
-    if (navigator.onLine && URL.SOCKET_URL !== '') {
+    if (
+      navigator.onLine &&
+      URL.SOCKET_URL !== '' &&
+      enterAgora.status !== 'CLOSED'
+    ) {
       connect();
     }
 
@@ -263,7 +259,8 @@ export default function Header() {
       </div>
       <div className="flex justify-center items-center">
         <AgoraTitle
-          title={metaData?.agora.title || ''}
+          title={metaData?.agora.title || enterAgora.title || ''}
+          isClosed={enterAgora.status === 'CLOSED'}
           pros={participants.pros}
           cons={participants.cons}
         />

--- a/src/app/(main)/flow/enter-agora/_components/EnterAgoraButton.tsx
+++ b/src/app/(main)/flow/enter-agora/_components/EnterAgoraButton.tsx
@@ -29,7 +29,8 @@ export default function EnterAgoraButton() {
 
   const mutation = useMutation({
     mutationFn: async () => {
-      const { selectedProfileImage, selectedPosition, nickname } = useEnter.getState();
+      const { selectedProfileImage, selectedPosition, nickname } =
+        useEnter.getState();
       const info = {
         ...selectedProfileImage,
         nickname,
@@ -37,7 +38,7 @@ export default function EnterAgoraButton() {
       };
       return postEnterAgoraInfo({ info, agoraId: selectedAgora.id });
     },
-    onSuccess: async (response) => {
+    onSuccess: (response) => {
       if (response) {
         setEnterAgora({
           id: response.agoraId,


### PR DESCRIPTION
### 🔗 Linked Issue
- [x] #35 

resolved: #35  

### 🛠 개발 기능
- 종료된 아고라의 경우 입장 시 저장한 전역 상태로 종료된 아고라인지 확인하여 웹소켓 미연결
- 종료된 아고라의 경우 찬/반 인원 미출력 (어차피 0명이기 때문)
- 데스크탑 라이트모드일 때 공유 모달의 로고 이름이 가려지는 문제 수정

### 🧩 해결 방법
- 아고라 입장시 저장하는 useAgora 전역 상태의 enterAgora.status를 사용하여 종료된 아고라인지 확인
- 종료된 아고라의 경우 찬/반 인원 미출력, 웹소켓 미연결

### 🔍 리뷰 포인트


<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
