### PR TITLE
[#52] 종료 아고라 입장시 바로 입장, 아고라 생성 후 전역 상태 reset

### DIFF
--- a/src/app/(main)/_components/atoms/Agora.tsx
+++ b/src/app/(main)/_components/atoms/Agora.tsx
@@ -2,13 +2,10 @@
 
 import { Agora as IAgora } from '@/app/model/Agora';
 import { useAgora } from '@/store/agora';
-import { useMutation } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
 import React from 'react';
-import showToast from '@/utils/showToast';
 import COLOR from '@/constants/agoraColor';
 import tokenManager from '@/utils/tokenManager';
-import { postEnterAgoraInfo } from '../../_lib/postEnterAgoraInfo';
 
 type Props = {
   agora: IAgora;
@@ -24,31 +21,15 @@ export default function Agora({ agora }: Props) {
     router.push(`/agoras/${id}`);
   };
 
-  const mutation = useMutation({
-    mutationFn: async () => {
-      const info = {
-        role: 'OBSERVER' as const,
-      };
-      return postEnterAgoraInfo({ info, agoraId: id });
-    },
-    onSuccess: async (response) => {
-      if (response) {
-        setEnterAgora({
-          id: response.agoraId,
-          title: agoraTitle,
-          status,
-          role: response.type,
-        });
-        routePage();
-      } else {
-        showToast('데이터 연결에 실패했습니다. 다시 시도해주세요.', 'error');
-      }
-    },
-    onError: () => {
-      // console.dir(error);
-      showToast('문제가 발생했습니다. 다시 시도해주세요.', 'error');
-    },
-  });
+  const redirectChat = () => {
+    setEnterAgora({
+      id,
+      title: agoraTitle,
+      status,
+      role: 'OBSERVER' as const,
+    });
+    routePage();
+  };
 
   // TODO: 아고라 id를 받아서 해당 아고라로 이동
   const enterAgora = () => {
@@ -60,7 +41,7 @@ export default function Agora({ agora }: Props) {
     } else if (AgoraStatus === 'closed') {
       // 바로 채팅방으로 이동
       tokenManager.clearRedirectUrl();
-      mutation.mutate();
+      redirectChat();
     }
   };
 

--- a/src/app/(main)/create-agora/_component/CreateAgoraBtn.tsx
+++ b/src/app/(main)/create-agora/_component/CreateAgoraBtn.tsx
@@ -92,8 +92,10 @@ function CreateAgoraBtn() {
     mutation.mutate();
   };
   useEffect(() => {
-    const { reset } = useCreateAgora.getState();
-    reset(); // 색상이나 카테고리를 눌러놓고, 채팅방에 나갔다 들어와서 다시 생성시 초기화 되도록 하기 위함
+    return () => {
+      const { reset } = useCreateAgora.getState();
+      reset(); // 언마운트시 초기화
+    };
   }, []);
   return (
     <div className="mt-1rem w-full">

--- a/src/app/(main)/create-agora/_component/CreateAgoraBtn.tsx
+++ b/src/app/(main)/create-agora/_component/CreateAgoraBtn.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMutation } from '@tanstack/react-query';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useCreateAgora } from '@/store/create';
 import { useRouter } from 'next/navigation';
 import { useAgora } from '@/store/agora';
@@ -91,7 +91,10 @@ function CreateAgoraBtn() {
     setIsLoading(true);
     mutation.mutate();
   };
-
+  useEffect(() => {
+    const { reset } = useCreateAgora.getState();
+    reset(); // 색상이나 카테고리를 눌러놓고, 채팅방에 나갔다 들어와서 다시 생성시 초기화 되도록 하기 위함
+  }, []);
   return (
     <div className="mt-1rem w-full">
       <button

--- a/src/store/create.ts
+++ b/src/store/create.ts
@@ -46,8 +46,8 @@ export const useCreateAgora = create(
     reset: () =>
       set({
         title: '',
-        category: '',
-        color: '',
+        category: '1',
+        color: 'agora-point-color1',
         capacity: DEFAULT_PARTICIPANTS_CNT,
         duration: DEFAULT_TIME,
       }),


### PR DESCRIPTION
### 🔗 Linked Issue

- [x] #52 

resolved: #52

### 🛠 개발 기능

- 종료 아고라 입장시, api 요청하지 않고 바로 입장
- 아고라 생성 후 및 처음 마운트될 때 전역 상태 초기화

### 🧩 해결 방법

- 문제를 어떻게 해결했는지 간략하게 설명해주세요.

### 🔍 리뷰 포인트

- 리뷰 시 어떤 부분에 집중해야 할지 명시해주세요.

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
