### PR TITLE
Retry 오류 token 개별 관리,  Modal 닫힐 때 reset 설정, [#53] 종료 투표 후, disabled 설정

### DIFF
--- a/src/app/(chat)/_components/molecules/DiscussionStatus.tsx
+++ b/src/app/(chat)/_components/molecules/DiscussionStatus.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMutation } from '@tanstack/react-query';
-import React, { Suspense } from 'react';
+import React, { Suspense, useState } from 'react';
 import EyeIcon from '@/assets/icons/EyeIcon';
 import { useChatInfo } from '@/store/chatInfo';
 import { useAgora } from '@/store/agora';
@@ -19,6 +19,7 @@ type Props = {
 };
 
 export default function DiscussionStatus({ meta }: Props) {
+  const [isEndClicked, setIsEndClicked] = useState(false);
   const { enterAgora } = useAgora();
   const { start } = useChatInfo(
     useShallow((state) => ({
@@ -45,6 +46,7 @@ export default function DiscussionStatus({ meta }: Props) {
     mutationFn: async () => patchAgoraEnd(enterAgora.id),
     onSuccess: async (response) => {
       if (response) {
+        setIsEndClicked(true);
         showToast('토론 종료에 투표하였습니다.', 'success');
       } else {
         showToast('토론 종료 투표에 실패했습니다.', 'error');
@@ -73,7 +75,11 @@ export default function DiscussionStatus({ meta }: Props) {
           type="button"
           onClick={toggleProgress}
           aria-label={`토론 ${start ? '종료하기' : '시작하기'}`}
-          className={`text-xs lg:text-sm italic ${start ? 'bg-athens-main' : 'bg-red-500'} p-4 pl-15 pr-15 under-mobile:pl-10 under-mobile:pr-10 rounded-lg text-white mr-0.5rem`}
+          className={`text-xs lg:text-sm italic 
+            ${start ? 'bg-athens-main' : 'bg-red-500'} 
+            ${isEndClicked ? 'opacity-60' : 'opacity-100'}
+          p-4 pl-15 pr-15 under-mobile:pl-10 under-mobile:pr-10 rounded-lg text-white mr-0.5rem`}
+          disabled={isEndClicked}
         >
           {start ? 'END' : 'START'}
         </button>

--- a/src/app/_components/molecules/ModalBase.tsx
+++ b/src/app/_components/molecules/ModalBase.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
 } from 'react';
 import { useRouter } from 'next/navigation';
+import { useCreateAgora } from '@/store/create';
 import RemoveButton from '../atoms/RemoveButton';
 
 type Props = {
@@ -53,8 +54,11 @@ export default function ModalBase({
   };
 
   const keyDownOutSideModal: KeyboardEventHandler<HTMLElement> = (e) => {
-    if (e.key === 'Enter' && e.target === e.currentTarget && removeIcon)
+    if (e.key === 'Enter' && e.target === e.currentTarget && removeIcon) {
+      const { reset } = useCreateAgora.getState();
+      reset(); // 언마운트시 초기화
       router.back();
+    }
   };
 
   return (

--- a/src/lib/fetchWrapper.ts
+++ b/src/lib/fetchWrapper.ts
@@ -57,6 +57,7 @@ class FetchWrapper {
 
     if (!response.ok) {
       retryConfig.retry -= 1;
+      console.log('retryConfig는 ', retryConfig.retry);
       if (response.status === 401 || response.status === 400) {
         await tokenErrorHandler(result);
         // 재발급 후 재요청

--- a/src/lib/getReissuanceToken.ts
+++ b/src/lib/getReissuanceToken.ts
@@ -19,20 +19,20 @@ export const getReissuanceToken = async () => {
 
   if (!res.ok) {
     const result = await res.json();
+    console.log('getReissuance에서 retry', retryConfig.tokenReissuance);
     if (result.error.code === 1003 || result.error.code === 1202) {
-      if (retryConfig.retry > 0) {
+      if (retryConfig.tokenReissuance > 0) {
+        retryConfig.tokenReissuance -= 1;
         await getToken();
         await getReissuanceToken();
-        retryConfig.retry -= 1;
-        console.log('retryConfig는', retryConfig.retry);
       }
     } else if (result.error.code === 1201) {
       if (
         result.error.message === 'Invalid JWT signature.' ||
         result.error.message === 'Unsupported JWT token.'
       ) {
-        if (retryConfig.retry > 0) {
-          retryConfig.retry -= 1;
+        if (retryConfig.tokenReissuance > 0) {
+          retryConfig.tokenReissuance -= 1;
           await getToken();
           await getReissuanceToken();
         }
@@ -41,15 +41,16 @@ export const getReissuanceToken = async () => {
       showToast('인증 오류가 발생했습니다.', 'error');
     }
 
-    if (retryConfig.retry < 1) {
+    if (retryConfig.tokenReissuance < 1) {
       showToast('인증 오류가 발생했습니다.', 'error');
-      retryConfig.retry = 3;
+      retryConfig.retry = 0;
+      retryConfig.tokenReissuance = 3;
     }
 
     return;
   }
 
-  retryConfig.retry = 3;
+  retryConfig.tokenReissuance = 3;
   const result = await res.json();
 
   tokenManager.setToken(result.response);

--- a/src/lib/getReissuanceToken.ts
+++ b/src/lib/getReissuanceToken.ts
@@ -19,7 +19,7 @@ export const getReissuanceToken = async () => {
 
   if (!res.ok) {
     const result = await res.json();
-    console.log('getReissuance에서 retry', retryConfig.tokenReissuance);
+
     if (result.error.code === 1003 || result.error.code === 1202) {
       if (retryConfig.tokenReissuance > 0) {
         retryConfig.tokenReissuance -= 1;

--- a/src/lib/getToken.ts
+++ b/src/lib/getToken.ts
@@ -26,8 +26,8 @@ const getToken = async () => {
         result.error.message === 'Invalid JWT signature.' ||
         result.error.message === 'Unsupported JWT token.'
       ) {
-        if (retryConfig.retry > 0) {
-          retryConfig.retry -= 1;
+        if (retryConfig.tokenRetry > 0) {
+          retryConfig.tokenRetry -= 1;
           await getToken();
         }
       }
@@ -35,15 +35,15 @@ const getToken = async () => {
       showToast('인증 오류가 발생했습니다.', 'error');
     }
 
-    if (retryConfig.retry < 1) {
+    if (retryConfig.tokenRetry < 1) {
       showToast('인증 오류가 발생했습니다.', 'error');
-      retryConfig.retry = 3;
+      retryConfig.tokenRetry = 3;
     }
 
     return;
   }
 
-  retryConfig.retry = 3;
+  retryConfig.tokenRetry = 3;
   const result = await res.json();
 
   tokenManager.setToken(result.response.accessToken);

--- a/src/lib/retryConfig.ts
+++ b/src/lib/retryConfig.ts
@@ -1,5 +1,9 @@
 class RetryConfig {
   retry = 3;
+
+  tokenRetry = 3;
+
+  tokenReissuance = 3;
 }
 
 const retryConfig = new RetryConfig();


### PR DESCRIPTION
### 🔗 Linked Issue

- [ ] #53

### 🛠 개발 기능

- Modal 닫힐 때 CreateAgora reset
- token은 개별 관리 하도록 수정하여 Retry 오류 해결
- 종료 투표 후, 한번 더 누르지 못하도록 disabled 설정

### 🧩 해결 방법

- agoraEnd가 onSuccess로 진입할 때, state관리를 통해 disabled 설정을 해주었습니다.

### 🔍 리뷰 포인트

- 리뷰 시 어떤 부분에 집중해야 할지 명시해주세요.

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
