### PR TITLE
#[62] 토론 종료시 유저 목록 초기화, 종료된 아고라 키워드 검색 후 입장시 모달 거치지 않도록 수정

### DIFF
--- a/src/app/(chat)/_components/organisms/AgoraUserSuspense.tsx
+++ b/src/app/(chat)/_components/organisms/AgoraUserSuspense.tsx
@@ -5,6 +5,8 @@ import { useQuery } from '@tanstack/react-query';
 import { AgoraUser } from '@/app/model/AgoraUser';
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import ErrorFallback from '@/app/_components/templates/ErrorFallback';
+import { useChatInfo } from '@/store/chatInfo';
+import { useShallow } from 'zustand/react/shallow';
 import AgoraUserList from '../molecules/AgoraUserList';
 import { getAgoraUsers } from '../../_lib/getAgoraUsers';
 
@@ -22,6 +24,12 @@ function FallbackComponent(props: FallbackProps) {
 }
 
 export default function AgoraUserSuspense({ agoraId }: Props) {
+  const { end } = useChatInfo(
+    useShallow((state) => ({
+      end: state.end,
+    })),
+  );
+
   const { data: userList } = useQuery<
     AgoraUser[],
     Object,
@@ -33,9 +41,10 @@ export default function AgoraUserSuspense({ agoraId }: Props) {
     staleTime: 1000 * 30,
     gcTime: 60 * 1000,
   });
+
   return (
     <div>
-      {userList && (
+      {userList && !end && (
         <ErrorBoundary FallbackComponent={FallbackComponent}>
           <AgoraUserList position="PROS" userList={userList} />
           <div className="border-b-1 border-gray-200 mb-1rem dark:border-gray-500" />

--- a/src/app/(main)/_components/atoms/SearchAgora.tsx
+++ b/src/app/(main)/_components/atoms/SearchAgora.tsx
@@ -21,7 +21,13 @@ export default function SearchAgora({ agora }: Props) {
   // TODO: 아고라 id를 받아서 해당 아고라로 이동
   const enterAgora = () => {
     setSelectedAgora({ id, title: agoraTitle, status });
-    router.push(`/flow/enter-agora/${id}`);
+
+    if (status === 'QUEUED' || status === 'RUNNING') {
+      router.push(`/flow/enter-agora/${id}`);
+    } else if (status === 'CLOSED') {
+      // 만약 status가 closed라면, /agoras/${id}로 이동
+      router.push(`/agoras/${id}`);
+    }
   };
 
   const handleKeyDownEnterAgora: KeyboardEventHandler<HTMLElement> = (e) => {


### PR DESCRIPTION
### 🔗 Linked Issue

- [ ] #62

resolved: #1 #2

### 🛠 개발 기능

- 종료된 아고라 키워드 검색 후 입장시 모달 거치지 않도록 수정
- 토론 종료시 유저 목록 보이지 않도록 수정

### 🧩 해결 방법

- 문제를 어떻게 해결했는지 간략하게 설명해주세요.

### 🔍 리뷰 포인트

- 리뷰 시 어떤 부분에 집중해야 할지 명시해주세요.

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
