### PR TITLE
QA2에서 발견한 서비스워커, 채팅방 문제

### DIFF
--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -114,21 +114,21 @@ export default function Header() {
               setDiscussionStart(data.data.agora.startAt);
             }
 
+            const partcipantsCnt = {
+              pros: 0,
+              cons: 0,
+            };
             data.data.participants.forEach(
               (participant: { type: string; count: number }) => {
                 if (participant.type === 'PROS') {
-                  setParticipants((prev) => ({
-                    ...prev,
-                    pros: participant.count,
-                  }));
+                  partcipantsCnt.pros = participant.count;
                 } else if (participant.type === 'CONS') {
-                  setParticipants((prev) => ({
-                    ...prev,
-                    cons: participant.count,
-                  }));
+                  partcipantsCnt.cons = participant.count;
                 }
               },
             );
+
+            setParticipants(partcipantsCnt);
           } else if (data.type === 'DISCUSSION_START') {
             // console.log(data.data);
             showToast('토론이 시작되었습니다.', 'success');

--- a/src/app/(chat)/agoras/[agora]/layout.tsx
+++ b/src/app/(chat)/agoras/[agora]/layout.tsx
@@ -1,3 +1,4 @@
+import ServiceWorkerRegistration from '@/app/_components/utils/ServiceWorkerRegistration';
 import React from 'react';
 
 type Props = {
@@ -8,6 +9,7 @@ type Props = {
 export default function Layout({ children, modal }: Props) {
   return (
     <div className="overflow-x-hidden justify-center items-center w-full h-full">
+      <ServiceWorkerRegistration />
       {children}
       {modal}
     </div>

--- a/src/utils/showToast.ts
+++ b/src/utils/showToast.ts
@@ -3,6 +3,7 @@ import toast from 'react-hot-toast';
 export default function showToast(message: string, type: string) {
   if (type === 'error') {
     toast(message, {
+      duration: 2000,
       icon: '❌',
       ariaProps: {
         role: 'alert',
@@ -17,6 +18,7 @@ export default function showToast(message: string, type: string) {
     });
   } else if (type === 'success') {
     toast(message, {
+      duration: 2000,
       icon: '✅',
       ariaProps: {
         role: 'alert',


### PR DESCRIPTION
### 🔗 Linked Issue

- [ ] #54 
- [ ] #62 

### 🛠 개발 기능

- 아고라 키워드 검색 시 종료 아고라 참여인원이 아닌 투표 결과 출력
- 서비스워커 상태 'redundant'로 변경시 서비스워커 재등록 및 채팅방 입장 전 서비스워커 상태 체크
- toast ui duration 2000ms로 조정
- 채팅방에서 한쪽 입장이 1명만 남은 상태에서 모두 나가면 0으로 변경되지 않는 문제 수정

### 🧩 해결 방법

- 타입 가이드를 사용하여 종료 아고라 데이터를 서버로부터 받으면 그에 맞게 출력문 조정
- 서비스워커 및 controller에 `statechange` 이벤트를 붙여 'redundant'로 상태 변경시 재등록
- meta 메시지를 받으면 기본값으로 초기화된 participants 객체를 생성하여 이 객체에 참여인원 저장, 상태 변경

### 🔍 리뷰 포인트

- 

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
