### PR TITLE
홈, 채팅 화면 리렌더링 최적화

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,28 @@ const nextConfig = {
     });
     return config;
   },
+  headers: async () => {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, no-cache, must-revalidate',
+          },
+        ],
+      },
+      { headers: [
+        {
+          key: 'Cache-Control',
+          value: 'public, max-age=86400, immutable',
+        },
+      ],
+
+      source: '/:path(.+\\.(?:ico|png|svg|jpg|jpeg|gif|webp|json|mp3|mp4|ttf|ttc|otf|woff|woff2)$)',
+    }
+    ];
+  }
 };
 
 const withPWA = require('next-pwa')({

--- a/src/app/(chat)/_components/atoms/HamburgerButton.tsx
+++ b/src/app/(chat)/_components/atoms/HamburgerButton.tsx
@@ -3,11 +3,20 @@ import React from 'react';
 
 type Props = {
   toggleMenu: () => void;
+  refetchUserList: () => void;
 };
 
-export default function HamburgerButton({ toggleMenu }: Props) {
+export default function HamburgerButton({
+  toggleMenu,
+  refetchUserList,
+}: Props) {
+  const handleClick = () => {
+    toggleMenu();
+    refetchUserList();
+  };
+
   return (
-    <button aria-label="메뉴 열기" onClick={toggleMenu} type="button">
+    <button aria-label="메뉴 열기" onClick={handleClick} type="button">
       <HamburgerIcon className="w-20 lg:w-22 cursor-pointer" />
     </button>
   );

--- a/src/app/(chat)/_components/atoms/MyMessage.tsx
+++ b/src/app/(chat)/_components/atoms/MyMessage.tsx
@@ -6,9 +6,14 @@ import UserImage from '../../../_components/atoms/UserImage';
 type Props = {
   message: Message;
   isSameUser: boolean;
+  shouldShowTime: boolean;
 };
 
-export default function MyMessage({ message, isSameUser }: Props) {
+export default function MyMessage({
+  message,
+  isSameUser,
+  shouldShowTime,
+}: Props) {
   return (
     <article
       className={`flex justify-end items-start p-0.5rem ${isSameUser && 'pt-0'} pr-12 pb-0 h-full`}
@@ -26,11 +31,16 @@ export default function MyMessage({ message, isSameUser }: Props) {
           </div>
         )}
         <div className="flex justify-end items-end">
-          <div className="flex flex-col justify-end items-end h-full">
-            <time className="text-xxs pr-8 h-full dark:text-dark-line">
-              {new Date(message.createdAt).toLocaleTimeString().slice(0, -3)}
-            </time>
-          </div>
+          {shouldShowTime && (
+            <div className="flex flex-col justify-end items-end h-full">
+              <time className="text-xxs pr-8 h-full dark:text-dark-line">
+                {message.createdAt &&
+                  new Date(message.createdAt)
+                    ?.toLocaleTimeString()
+                    .slice(0, -3)}
+              </time>
+            </div>
+          )}
           <div
             className={`max-w-[60vw] whitespace-pre-line ${message.user.type === 'CONS' ? 'bg-red-200' : 'bg-blue-200'} rounded-tl-lg ${isSameUser && 'rounded-tr-lg'} rounded-bl-lg rounded-br-lg p-7 pl-10 pr-10 text-xs lg:text-sm`}
           >

--- a/src/app/(chat)/_components/atoms/YourMessage.tsx
+++ b/src/app/(chat)/_components/atoms/YourMessage.tsx
@@ -6,9 +6,14 @@ import UserImage from '../../../_components/atoms/UserImage';
 type Props = {
   message: Message;
   isSameUser: boolean;
+  shouldShowTime: boolean;
 };
 
-export default function YourMessage({ message, isSameUser }: Props) {
+export default function YourMessage({
+  message,
+  isSameUser,
+  shouldShowTime,
+}: Props) {
   return (
     <article
       className={`flex justify-start items-start p-0.5rem ${isSameUser && 'pt-0'} pl-12 pb-0 h-full`}
@@ -51,11 +56,14 @@ export default function YourMessage({ message, isSameUser }: Props) {
           >
             {message.content}
           </div>
-          <div className="flex flex-col justify-end items-end h-full">
-            <time className="text-xxs pl-8 h-full dark:text-dark-line">
-              {new Date(message.createdAt).toLocaleTimeString().slice(0, -3)}
-            </time>
-          </div>
+          {shouldShowTime && (
+            <div className="flex flex-col justify-end items-end h-full">
+              <time className="text-xxs pl-8 h-full dark:text-dark-line">
+                {message.createdAt &&
+                  new Date(message.createdAt).toLocaleTimeString().slice(0, -3)}
+              </time>
+            </div>
+          )}
         </div>
       </div>
     </article>

--- a/src/app/(chat)/_components/molecules/Message.tsx
+++ b/src/app/(chat)/_components/molecules/Message.tsx
@@ -16,6 +16,8 @@ interface Meta {
   effectiveSize: number;
 }
 
+const observer = 'OBSERVER';
+
 export default function Message() {
   const [pageRendered, setPageRendered] = useState(false);
   const [adjustScroll, setAdjustScroll] = useState(false);
@@ -81,33 +83,59 @@ export default function Message() {
     }
   }, [shouldGoDown, setGoDown]);
 
+  const isMyType = (type: string) => type === myRole || type === observer;
+
+  const getTimeString = (time: string) => {
+    const date = new Date(time);
+    return date.toLocaleTimeString().slice(0, -3);
+  };
+
+  let prevChatSendTime = '';
   return (
     <div key={agoraId} ref={listRef} className="overflow-y-auto flex-1">
       {!adjustScroll && pageRendered && <div ref={ref} className="h-1" />}
       {data.pages.length &&
-        data.pages.map((page) => (
-          <div key={page.chats[0]?.chatId || Math.random()}>
-            {page.chats.map((message, idx) => (
+        data?.pages
+          ?.map((page) => page.chats)
+          ?.flat()
+          ?.map((message, idx, allMessages) => {
+            const previousMessage = { ...allMessages[idx - 1] }; // 불변성 유지를 위해 복사
+            const prevMessageTimeString =
+              idx > 0 ? getTimeString(previousMessage.createdAt) : '';
+            const currentMessageTimeString = getTimeString(message.createdAt);
+            const isSameUser =
+              idx > 0 && previousMessage.user.id === message.user.id;
+            const isSameTime =
+              idx > 0 &&
+              isSameUser &&
+              (prevMessageTimeString === currentMessageTimeString ||
+                prevChatSendTime === prevMessageTimeString);
+            const shouldShowTime = !isSameTime;
+
+            if (isSameTime) {
+              prevChatSendTime = '';
+            } else {
+              prevChatSendTime = currentMessageTimeString;
+            }
+
+            return (
               <div key={message.chatId}>
-                {message.user.type === myRole ? (
+                {isMyType(message.user.type) ? (
                   <MyMessage
+                    shouldShowTime={shouldShowTime}
                     message={message}
-                    isSameUser={
-                      idx > 0 && page.chats[idx - 1].user.id === message.user.id
-                    }
+                    isSameUser={isSameUser}
                   />
                 ) : (
                   <YourMessage
+                    shouldShowTime={shouldShowTime}
                     message={message}
-                    isSameUser={
-                      idx > 0 && page.chats[idx - 1].user.id === message.user.id
-                    }
+                    isSameUser={isSameUser}
                   />
                 )}
               </div>
-            ))}
-          </div>
-        ))}
+            );
+          })}
       <ChatNotification />
     </div>
   );

--- a/src/app/(chat)/_components/organisms/ErrorBoundaryMessage.tsx
+++ b/src/app/(chat)/_components/organisms/ErrorBoundaryMessage.tsx
@@ -3,7 +3,7 @@
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import ErrorFallback from '@/app/_components/templates/ErrorFallback';
 import React from 'react';
-import Message from '../molecules/Message';
+import MessageContainer from './MessageContainer';
 
 const errorFallbackProps = {
   headerLabel: '채팅 불러오기 오류',
@@ -14,10 +14,14 @@ function FallbackComponent(props: FallbackProps) {
   return <ErrorFallback {...props} {...errorFallbackProps} />;
 }
 
-export default function ErrorBoundaryMessage() {
+type Props = {
+  agoraId: string;
+};
+
+export default function ErrorBoundaryMessage({ agoraId }: Props) {
   return (
     <ErrorBoundary FallbackComponent={FallbackComponent}>
-      <Message />
+      <MessageContainer agoraId={agoraId} />
     </ErrorBoundary>
   );
 }

--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -94,7 +94,7 @@ export default function Header() {
       setTitle(response.data.agora.title);
       setAgoraId(response.data.agora.id);
       setMetaData(response.data);
-      refetchAgoraUserList();
+      // refetchAgoraUserList();
 
       if (response.data.agora.startAt) {
         setDiscussionStart(response.data.agora.startAt);
@@ -271,7 +271,10 @@ export default function Header() {
         </div>
         <div className="flex justify-end items-center mr-0.5rem">
           <ShareButton title={metaData?.agora.title || ''} />
-          <HamburgerButton toggleMenu={toggle} />
+          <HamburgerButton
+            toggleMenu={toggle}
+            refetchUserList={refetchAgoraUserList}
+          />
         </div>
       </div>
       <div className="flex justify-center items-center">

--- a/src/app/(chat)/_components/organisms/MessageContainer.tsx
+++ b/src/app/(chat)/_components/organisms/MessageContainer.tsx
@@ -1,0 +1,28 @@
+import {
+  HydrationBoundary,
+  dehydrate,
+  useQueryClient,
+} from '@tanstack/react-query';
+import React from 'react';
+import { getChatMessages } from '../../_lib/getChatMessages';
+import Message from '../molecules/Message';
+
+type Props = {
+  agoraId: string;
+};
+
+export default async function MessageContainer({ agoraId }: Props) {
+  const queryClient = useQueryClient();
+  await queryClient.prefetchInfiniteQuery({
+    queryKey: ['chat', `${agoraId}`, 'messages'],
+    queryFn: getChatMessages,
+    initialPageParam: { meta: { key: null, effectiveSize: 20 } },
+  });
+  const dehydratedState = dehydrate(queryClient);
+
+  return (
+    <HydrationBoundary state={dehydratedState}>
+      <Message />
+    </HydrationBoundary>
+  );
+}

--- a/src/app/(chat)/agoras/[agora]/page.tsx
+++ b/src/app/(chat)/agoras/[agora]/page.tsx
@@ -43,10 +43,16 @@ export async function generateMetadata() {
   };
 }
 
-export default function Page() {
+type Props = {
+  params: {
+    agora: string;
+  };
+};
+
+export default function Page({ params }: Props) {
   return (
     <main aria-label="채팅" className="flex flex-col justify-between h-full">
-      <ErrorBoundaryMessage />
+      <ErrorBoundaryMessage agoraId={params.agora} />
     </main>
   );
 }

--- a/src/app/(main)/_components/atoms/CategoryAgora.tsx
+++ b/src/app/(main)/_components/atoms/CategoryAgora.tsx
@@ -38,7 +38,7 @@ export default function CategoryAgora({ agora }: Props) {
       status: agora.status,
     });
 
-    const AgoraStatus = searchParams.get('status');
+    const AgoraStatus = searchParams.get('status') || 'active';
 
     if (AgoraStatus === 'active') {
       router.push(`/flow/enter-agora/${agora.id}`);

--- a/src/app/(main)/_components/atoms/SearchBar.tsx
+++ b/src/app/(main)/_components/atoms/SearchBar.tsx
@@ -30,7 +30,14 @@ function SearchBar() {
     setSearchText('');
     const newSearchParams = new URLSearchParams(searchParams);
     newSearchParams.delete('q');
-    router.push(`/home?${newSearchParams.toString()}`);
+
+    const newUrl = `/home?${newSearchParams.toString()}`;
+    window.history.pushState(
+      { ...window.history.state, as: newUrl, url: newUrl },
+      '',
+      newUrl,
+    );
+    // router.push(newUrl);
   };
 
   const changeInputText: ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -42,15 +49,33 @@ function SearchBar() {
     setSearch(searchText);
 
     if (!searchText) {
-      router.push('/home');
+      const newUrl = '/home';
+      window.history.pushState(
+        { ...window.history.state, as: newUrl, url: newUrl },
+        '',
+        newUrl,
+      );
+      // router.push('/home');
     } else {
-      router.push(`/home?q=${searchText}&status=active`);
+      const newUrl = `/home?q=${searchText}&status=active`;
+      window.history.pushState(
+        { ...window.history.state, as: newUrl, url: newUrl },
+        '',
+        newUrl,
+      );
+      // router.push(`/home?q=${searchText}&status=active`);
     }
   };
 
   useEffect(() => {
     if (search) {
-      router.push(`/home?q=${search}&status=active`);
+      const newUrl = `/home?q=${search}&status=active`;
+      window.history.pushState(
+        { ...window.history.state, as: newUrl, url: newUrl },
+        '',
+        newUrl,
+      );
+      // router.push(`/home?q=${search}&status=active`);
     }
   }, [router, search]);
 

--- a/src/app/(main)/_components/molecules/AgoraListDecider.tsx
+++ b/src/app/(main)/_components/molecules/AgoraListDecider.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import React, { Suspense } from 'react';
+import React, { useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import ErrorFallback from '@/app/_components/templates/ErrorFallback';
 import { SearchParams } from '@/app/model/Agora';
 import Loading from '@/app/_components/atoms/loading';
+import { useSearchStore } from '@/store/search';
+import { useShallow } from 'zustand/react/shallow';
 
 const KeywordAgoraList = dynamic(() => import('./KeywordAgoraList'), {
   loading: () => (
@@ -33,38 +35,30 @@ function FallbackComponent(props: FallbackProps) {
 }
 export default function AgoraListDecider({ searchParams }: Props) {
   const { q } = searchParams;
+  const { search, setSearch } = useSearchStore(
+    useShallow((state) => ({
+      search: state.search,
+      setSearch: state.setSearch,
+    })),
+  );
 
-  if (q) {
+  useEffect(() => {
+    if (q) {
+      setSearch(q);
+    }
+  }, []);
+
+  if (search) {
     return (
       <ErrorBoundary FallbackComponent={FallbackComponent}>
-        <Suspense
-          fallback={
-            <Loading
-              w="25"
-              h="25"
-              className="m-5 flex justify-center items-center"
-            />
-          }
-        >
-          <KeywordAgoraList searchParams={searchParams} />
-        </Suspense>
+        <KeywordAgoraList searchParams={searchParams} />
       </ErrorBoundary>
     );
   }
 
   return (
     <ErrorBoundary FallbackComponent={FallbackComponent}>
-      <Suspense
-        fallback={
-          <Loading
-            w="25"
-            h="25"
-            className="m-5 flex justify-center items-center"
-          />
-        }
-      >
-        <CategoryAgoraList searchParams={searchParams} />
-      </Suspense>
+      <CategoryAgoraList searchParams={searchParams} />
     </ErrorBoundary>
   );
 }

--- a/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
@@ -1,36 +1,72 @@
 'use client';
 
 import React, { useEffect } from 'react';
-import { InfiniteData, useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import {
+  InfiniteData,
+  useQueryClient,
+  useSuspenseInfiniteQuery,
+} from '@tanstack/react-query';
 import { AgoraData, SearchParams } from '@/app/model/Agora';
 import { useInView } from 'react-intersection-observer';
-import CategoryAgora from '../atoms/CategoryAgora';
-import { getAgoraCategorySearch } from '../../_lib/getAgoraCategorySearch';
+import DeferredComponent from '@/app/_components/utils/DefferedComponent';
+import Loading from '@/app/_components/atoms/loading';
+import { useCreateAgora } from '@/store/create';
+import { useShallow } from 'zustand/react/shallow';
 import NoAgoraMessage from '../atoms/NoAgoraMessage';
+import { getAgoraCategorySearch } from '../../_lib/getAgoraCategorySearch';
+import CategoryAgora from '../atoms/CategoryAgora';
 
 type Props = {
   searchParams: SearchParams;
 };
 
 export default function CategoryAgoraList({ searchParams }: Props) {
-  const { data, hasNextPage, fetchNextPage, isFetching } =
-    useSuspenseInfiniteQuery<
-      { agoras: AgoraData[]; nextCursor: number | null },
-      Object,
-      InfiniteData<{ agoras: AgoraData[]; nextCursor: number | null }>,
-      [_1: string, _2: string, _3: string, Props['searchParams']],
-      { nextCursor: number | null }
-    >({
-      queryKey: ['agoras', 'search', 'category', searchParams],
-      queryFn: getAgoraCategorySearch,
-      staleTime: 60 * 1000,
-      gcTime: 500 * 1000,
-      initialPageParam: { nextCursor: null },
-      getNextPageParam: (lastPage) =>
-        lastPage.nextCursor !== null
-          ? { nextCursor: lastPage.nextCursor }
-          : undefined,
-    });
+  const queryClient = useQueryClient();
+
+  const { category: selectedCategory } = useCreateAgora(
+    useShallow((state) => ({
+      setCategory: state.setCategory,
+      category: state.category,
+    })),
+  );
+
+  const {
+    data,
+    hasNextPage,
+    fetchNextPage,
+    isFetching,
+    isPending,
+    isFetchingNextPage,
+  } = useSuspenseInfiniteQuery<
+    { agoras: AgoraData[]; nextCursor: number | null },
+    Object,
+    InfiniteData<{ agoras: AgoraData[]; nextCursor: number | null }>,
+    [_1: string, _2: string, _3: string, Props['searchParams']],
+    { nextCursor: number | null }
+  >({
+    queryKey: [
+      'agoras',
+      'search',
+      'category',
+      { ...searchParams, category: selectedCategory },
+    ],
+    queryFn: getAgoraCategorySearch,
+    staleTime: 60 * 1000,
+    gcTime: 500 * 1000,
+    initialPageParam: { nextCursor: null },
+    getNextPageParam: (lastPage) =>
+      lastPage.nextCursor !== null
+        ? { nextCursor: lastPage.nextCursor }
+        : undefined,
+    initialData: () => {
+      return queryClient.getQueryData([
+        'agoras',
+        'search',
+        'category',
+        searchParams,
+      ]);
+    },
+  });
 
   const { ref, inView } = useInView({
     threshold: 0,
@@ -44,22 +80,40 @@ export default function CategoryAgoraList({ searchParams }: Props) {
     }
   }, [inView, hasNextPage, fetchNextPage, isFetching]);
 
+  useEffect(() => {
+    // 초기 데이터 호출 후 카테고리 변경 시 데이터 재호출
+    queryClient.invalidateQueries({
+      queryKey: [
+        'agoras',
+        'search',
+        'category',
+        { ...searchParams, category: selectedCategory },
+      ],
+    });
+  }, [selectedCategory, queryClient]);
+
   return (
     <>
       {data?.pages[0].agoras.length < 1 ? (
         <NoAgoraMessage />
       ) : (
         <div className="grid under-large:grid-cols-5 gap-x-1rem gap-y-1rem under-mobile:grid-cols-2 mobile:grid-cols-2 foldable:grid-cols-3 tablet:grid-cols-4 under-tablet:grid-cols-4 xl:grid-cols-6 sm:grid-cols-3 lg:grid-cols-5 under-xl:grid-cols-4">
-          {data?.pages.map((page) => (
-            <React.Fragment key={page.agoras[0]?.id}>
-              {page.agoras.map((agora) => (
-                <CategoryAgora key={agora.id} agora={agora} />
-              ))}
-            </React.Fragment>
-          ))}
+          {data?.pages
+            ?.map((page) => page.agoras)
+            ?.flat()
+            ?.map((agora) => <CategoryAgora key={agora.id} agora={agora} />)}
+          <div ref={ref} />
         </div>
       )}
-      <div ref={ref} />
+      {(isFetching || isPending || isFetchingNextPage) && (
+        <DeferredComponent>
+          <Loading
+            w="32"
+            h="32"
+            className="m-5 flex justify-center items-center"
+          />
+        </DeferredComponent>
+      )}
     </>
   );
 }

--- a/src/app/(main)/_components/molecules/CategoryButtonList.tsx
+++ b/src/app/(main)/_components/molecules/CategoryButtonList.tsx
@@ -26,6 +26,16 @@ export default function CategoryButtonList() {
     })),
   );
 
+  useEffect(() => {
+    if (categorySearchParams) {
+      setCategory(categorySearchParams);
+    }
+
+    return () => {
+      setCategory('1');
+    };
+  }, []);
+
   const changeCategoryParams = useCallback(
     (id: string) => {
       if (pathname !== '/home') return;
@@ -36,10 +46,15 @@ export default function CategoryButtonList() {
       newSearchParams.delete('q');
       search.reset();
 
-      // window.history.pushState(null, '', `/home?${newSearchParams.toString()}`)
-      router.push(`/home?${newSearchParams.toString()}`);
+      const newUrl = `/home?${newSearchParams.toString()}`;
+      window.history.pushState(
+        { ...window.history.state, as: newUrl, url: newUrl },
+        '',
+        newUrl,
+      );
+      // router.push(`/home?${newSearchParams.toString()}`);
     },
-    [router, searchParams, pathname],
+    [router, searchParams, pathname, selectedCategory],
   );
 
   useEffect(() => {
@@ -81,9 +96,7 @@ export default function CategoryButtonList() {
             >
               <CategoryButton
                 innerText={category.innerText}
-                isActive={
-                  category.value === (categorySearchParams || selectedCategory)
-                }
+                isActive={category.value === selectedCategory}
               />
             </button>
           ))}

--- a/src/app/(main)/_components/molecules/KeywordAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/KeywordAgoraList.tsx
@@ -1,36 +1,67 @@
 'use client';
 
 import React, { useEffect } from 'react';
-import { InfiniteData, useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import {
+  InfiniteData,
+  useQueryClient,
+  useSuspenseInfiniteQuery,
+} from '@tanstack/react-query';
 import { Agora as IAgora, SearchParams } from '@/app/model/Agora';
 import { useInView } from 'react-intersection-observer';
-import KeywordAgora from '../atoms/KeywordAgora';
-import { getAgoraKeywordSearch } from '../../_lib/getAgoraKeywordSearch';
+import { useSearchStore } from '@/store/search';
+import { useShallow } from 'zustand/react/shallow';
+import DeferredComponent from '@/app/_components/utils/DefferedComponent';
+import Loading from '@/app/_components/atoms/loading';
 import NoAgoraMessage from '../atoms/NoAgoraMessage';
+import { getAgoraKeywordSearch } from '../../_lib/getAgoraKeywordSearch';
+import KeywordAgora from '../atoms/KeywordAgora';
 
 type Props = {
   searchParams: SearchParams;
 };
 
 export default function KeywordAgoraList({ searchParams }: Props) {
-  const { data, hasNextPage, fetchNextPage, isFetching } =
-    useSuspenseInfiniteQuery<
-      { agoras: IAgora[]; nextCursor: number | null },
-      Object,
-      InfiniteData<{ agoras: IAgora[]; nextCursor: number | null }>,
-      [_1: string, _2: string, _3: string, Props['searchParams']],
-      { nextCursor: number | null }
-    >({
-      queryKey: ['agoras', 'search', 'keyword', searchParams],
-      queryFn: getAgoraKeywordSearch,
-      staleTime: 60 * 1000,
-      gcTime: 500 * 1000,
-      initialPageParam: { nextCursor: null },
-      getNextPageParam: (lastPage) =>
-        lastPage.nextCursor !== null
-          ? { nextCursor: lastPage.nextCursor }
-          : undefined,
-    });
+  const queryClient = useQueryClient();
+  const { search } = useSearchStore(
+    useShallow((state) => ({
+      search: state.search,
+    })),
+  );
+
+  const {
+    data,
+    hasNextPage,
+    fetchNextPage,
+    isFetching,
+    isPending,
+    isFetchingNextPage,
+  } = useSuspenseInfiniteQuery<
+    { agoras: IAgora[]; nextCursor: number | null },
+    Object,
+    InfiniteData<{ agoras: IAgora[]; nextCursor: number | null }>,
+    [_1: string, _2: string, _3: string, Props['searchParams']],
+    { nextCursor: number | null }
+  >({
+    queryKey: ['agoras', 'search', 'keyword', { ...searchParams, q: search }],
+    queryFn: getAgoraKeywordSearch,
+    staleTime: 60 * 1000,
+    gcTime: 500 * 1000,
+    initialPageParam: { nextCursor: null },
+    getNextPageParam: (lastPage) =>
+      lastPage.nextCursor !== null
+        ? { nextCursor: lastPage.nextCursor }
+        : undefined,
+    initialData: () => {
+      if (searchParams.q && !search)
+        return queryClient.getQueryData([
+          'agoras',
+          'search',
+          'keyword',
+          searchParams,
+        ]);
+      return undefined;
+    },
+  });
 
   const { ref, inView } = useInView({
     threshold: 0,
@@ -49,13 +80,19 @@ export default function KeywordAgoraList({ searchParams }: Props) {
       {data?.pages[0].agoras.length < 1 ? (
         <NoAgoraMessage />
       ) : (
-        data?.pages.map((page) => (
-          <React.Fragment key={page.agoras[0]?.id || 0}>
-            {page.agoras.map((agora) => (
-              <KeywordAgora key={agora.id} agora={agora} />
-            ))}
-          </React.Fragment>
-        ))
+        data?.pages
+          ?.map((page) => page.agoras)
+          ?.flat()
+          ?.map((agora) => <KeywordAgora key={agora.id} agora={agora} />)
+      )}
+      {(isFetching || isPending || isFetchingNextPage) && (
+        <DeferredComponent>
+          <Loading
+            w="32"
+            h="32"
+            className="m-5 flex justify-center items-center"
+          />
+        </DeferredComponent>
       )}
       <div ref={ref} />
     </>

--- a/src/app/(main)/_components/organisms/AgoraListDeciderHydration.tsx
+++ b/src/app/(main)/_components/organisms/AgoraListDeciderHydration.tsx
@@ -7,18 +7,25 @@ import React from 'react';
 import { SearchParams } from '@/app/model/Agora';
 import { getAgoraCategorySearch } from '../../_lib/getAgoraCategorySearch';
 import AgoraListDecider from '../molecules/AgoraListDecider';
+import { getAgoraKeywordSearch } from '../../_lib/getAgoraKeywordSearch';
 
 type Props = {
   searchParams: SearchParams;
 };
 
-export default async function AgoraListDeciderSuspense({
+export default async function AgoraListDeciderHydration({
   searchParams,
 }: Props) {
   const queryClient = new QueryClient();
+  const isSearch = searchParams.q;
   await queryClient.prefetchInfiniteQuery({
-    queryKey: ['agoras', 'search', 'category', searchParams],
-    queryFn: getAgoraCategorySearch,
+    queryKey: [
+      'agoras',
+      'search',
+      isSearch ? 'keyword' : 'category',
+      searchParams,
+    ],
+    queryFn: isSearch ? getAgoraKeywordSearch : getAgoraCategorySearch,
     initialPageParam: { nextCursor: null },
   });
   const dehydratedState = dehydrate(queryClient);

--- a/src/app/(main)/_components/templates/Main.tsx
+++ b/src/app/(main)/_components/templates/Main.tsx
@@ -7,8 +7,8 @@ type Props = {
   searchParams: SearchParams;
 };
 
-const AgoraListDeciderSuspense = dynamic(
-  () => import('../organisms/AgoraListDeciderSuspense'),
+const AgoraListDeciderHydration = dynamic(
+  () => import('../organisms/AgoraListDeciderHydration'),
 );
 
 export default function Main({ searchParams }: Props) {
@@ -23,7 +23,7 @@ export default function Main({ searchParams }: Props) {
             <Loading className="m-5 flex justify-center items-center" />
           }
         >
-          <AgoraListDeciderSuspense searchParams={searchParams} />
+          <AgoraListDeciderHydration searchParams={searchParams} />
         </Suspense>
       </section>
     </main>

--- a/src/app/(main)/create-agora/_component/AgoraTitleInput.tsx
+++ b/src/app/(main)/create-agora/_component/AgoraTitleInput.tsx
@@ -1,11 +1,15 @@
 'use client';
 
 import { useCreateAgora } from '@/store/create';
-import React, { ChangeEventHandler, useState } from 'react';
+import { useSearchStore } from '@/store/search';
+import { useRouter } from 'next/navigation';
+import React, { ChangeEventHandler, useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
 function AgoraTitleInput() {
   const [message, setMessage] = useState<string | null>('주제를 입력해주세요.');
+  const { reset } = useSearchStore();
+  const router = useRouter();
   const { title, setTitle } = useCreateAgora(
     useShallow((state) => ({
       title: state.title,
@@ -24,6 +28,16 @@ function AgoraTitleInput() {
       setMessage(null);
     }
   };
+
+  const dataReset = () => {
+    setTitle('');
+    setMessage(null);
+    reset();
+  };
+
+  useEffect(() => {
+    dataReset();
+  }, [router]);
 
   return (
     <>

--- a/src/app/_components/utils/DefferedComponent.tsx
+++ b/src/app/_components/utils/DefferedComponent.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+// 로딩이 시작된 후 특정 시점까지 로더를 보여주지 않기 위한 용도
+export default function DeferredComponent({ children }: Props) {
+  const [isDeferred, setIsDeferred] = useState(false);
+
+  useEffect(() => {
+    // 200ms 지난 후 children render
+    const timeoutId = setTimeout(() => {
+      setIsDeferred(true);
+    }, 200);
+
+    return () => clearTimeout(timeoutId);
+  }, []);
+
+  if (!isDeferred) {
+    return null;
+  }
+
+  return children;
+}


### PR DESCRIPTION
### 🔗 Linked Issue

- [ ] #66 

### 🛠 개발 기능

- 홈 화면에서 카테고리 클릭마다 페이지 전체 리렌더링 문제 해결
- 키워드 검색 시마다 페이지 전체 리렌더링 문제 해결
- 채팅방 유저 리스트 meta type 소켓 응답 받을 때마다 호출 수정
- 채팅방 전송 시간 카톡처럼 마지막 전송 시간만 보이도록 수정
- 서버 컴포넌트에서 prefetch한 데이터 사용하도록 수정
- fetch 중일 때마다 로더가 보이는 것이 아닌, 일정 시간이 지난 후 보이도록 수정하여 UX 향상 도모

### 🧩 해결 방법

- shallow routing을 사용하여 url만 변경되고 화면은 리렌더링이 되지 않도록 한다.

- shallow routing으로 url이 변경되면, 이를 useSearchParam은 감지하지 못하기 때문에 상태 변화를 줄 수 없게 된다. 그렇기에 전역 상태를 사용하여 직접 상태를 감지하여 필요한 부분만 리렌더링이 진행되도록 수정하였다.

- 홈에서 서버컴포넌트에서 미리 데이터를 prefetch하여 아고라 리스트를 불러준다. 해당 데이터를 react query의 InitialData property에 추가해주어 초기 렌더링 시 서버 컴포넌트에서 호출한 데이터를 보여주도록 하였다.

- 데이터 fetch 때마다 로더가 보이도록 한다면, 빠른 시간 안에 서버로부터 데이터를 받게 될 때 사용자는 로더나 스켈레톤으로 인해 화면이 깜빡이는 것 같은 느낌을 받을 수 있다. 이러한 현상을 줄이기 위해 일정 시간이 지난 후에만 로더가 출력되도록 DefferedComponent를 추가해주었다.

### 🔍 리뷰 포인트

- shallow routing에 대해 이해하고 이를 적용하기 위해 어떻게 코드를 수정했는지 봐주세요

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
