### PR TITLE
종료 아고라 그래프 표현, 인기 아고라 구현

### DIFF
--- a/src/app/(chat)/_components/organisms/MessageContainer.tsx
+++ b/src/app/(chat)/_components/organisms/MessageContainer.tsx
@@ -1,7 +1,7 @@
 import {
   HydrationBoundary,
+  QueryClient,
   dehydrate,
-  useQueryClient,
 } from '@tanstack/react-query';
 import React from 'react';
 import { getChatMessages } from '../../_lib/getChatMessages';
@@ -12,7 +12,7 @@ type Props = {
 };
 
 export default async function MessageContainer({ agoraId }: Props) {
-  const queryClient = useQueryClient();
+  const queryClient = new QueryClient();
   await queryClient.prefetchInfiniteQuery({
     queryKey: ['chat', `${agoraId}`, 'messages'],
     queryFn: getChatMessages,

--- a/src/app/(main)/_components/atoms/CategoryAgora.tsx
+++ b/src/app/(main)/_components/atoms/CategoryAgora.tsx
@@ -40,7 +40,9 @@ export default function CategoryAgora({ agora, className }: Props) {
     });
 
     const AgoraStatus =
-      agora.status === ('RUNNING' || 'QUEUED') ? 'active' : 'closed';
+      agora.status === 'RUNNING' || agora.status === 'QUEUED'
+        ? 'active'
+        : 'closed';
 
     if (AgoraStatus === 'active') {
       router.push(`/flow/enter-agora/${agora.id}`);
@@ -72,7 +74,7 @@ export default function CategoryAgora({ agora, className }: Props) {
           />
         )}
       </div>
-      <h3 className="text-xs under-mobile:text-xs under-mobile:font-semibold pt-10 dark:text-white break-all w-full text-center">
+      <h3 className="text-xs under-mobile:font-semibold pt-10 dark:text-white break-all w-full text-center">
         {agora.agoraTitle}
       </h3>
       <div
@@ -96,7 +98,7 @@ export default function CategoryAgora({ agora, className }: Props) {
               </span>
               {agora.participants.cons}명
             </span>
-            <span className="under-mobile:bloc break-keep">
+            <span className="under-mobile:block break-keep">
               <span className="pr-3 dark:text-white dark:text-opacity-85">
                 관찰자
               </span>
@@ -107,8 +109,9 @@ export default function CategoryAgora({ agora, className }: Props) {
           </>
         ) : (
           <ClosedAgoraVoteResultBar
-            prosPercentage={agora.prosCount}
-            consPercentage={agora.consCount}
+            prosCount={agora.prosCount}
+            consCount={agora.consCount}
+            totalMember={agora.totalMember}
           />
         )}
       </div>

--- a/src/app/(main)/_components/atoms/ClosedAgoraVoteResultBar.tsx
+++ b/src/app/(main)/_components/atoms/ClosedAgoraVoteResultBar.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
 
 type Props = {
-  prosPercentage: number;
-  consPercentage: number;
+  prosCount: number;
+  consCount: number;
+  totalMember: number;
 };
 
 export default function ClosedAgoraVoteResultBar({
-  prosPercentage,
-  consPercentage,
+  prosCount,
+  consCount,
+  totalMember,
 }: Props) {
-  const total = prosPercentage + consPercentage;
   const consWidth =
-    consPercentage <= 0 ? 0 : Math.floor((total / consPercentage) * 100);
+    consCount <= 0 ? 0 : Math.floor((consCount / totalMember) * 100);
   const prosWidth =
-    prosPercentage <= 0 ? 0 : Math.floor((total / prosPercentage) * 100);
+    prosCount <= 0 ? 0 : Math.floor((prosCount / totalMember) * 100);
 
   return (
     <div className="w-full h-full px-4 text-xxs">
@@ -21,7 +22,7 @@ export default function ClosedAgoraVoteResultBar({
         찬성
         <div className="w-full flex ml-5 h-16">
           <div
-            className="bg-dark-pro-color rounded-r-lg h-full"
+            className="bg-dark-pro-color rounded-r-md h-full"
             style={{ width: `${prosWidth || 1}%` }}
           />
         </div>
@@ -31,7 +32,7 @@ export default function ClosedAgoraVoteResultBar({
         반대
         <div className="w-full flex ml-5 h-16">
           <div
-            className="bg-dark-con-color rounded-r-lg"
+            className="bg-dark-con-color rounded-r-md"
             style={{ width: `${consWidth || 1}%` }}
           />
         </div>

--- a/src/app/(main)/_components/atoms/KeywordAgora.tsx
+++ b/src/app/(main)/_components/atoms/KeywordAgora.tsx
@@ -95,8 +95,9 @@ export default function KeywordAgora({ agora }: Props) {
               </div>
             ) : (
               <ClosedAgoraVoteResultBar
-                prosPercentage={agora.prosCount}
-                consPercentage={agora.consCount}
+                prosCount={agora.prosCount}
+                consCount={agora.consCount}
+                totalMember={agora.totalMember}
               />
             )}
           </div>

--- a/src/app/(main)/_components/molecules/AgoraListDecider.tsx
+++ b/src/app/(main)/_components/molecules/AgoraListDecider.tsx
@@ -8,6 +8,7 @@ import { SearchParams } from '@/app/model/Agora';
 import Loading from '@/app/_components/atoms/loading';
 import { useSearchStore } from '@/store/search';
 import { useShallow } from 'zustand/react/shallow';
+import LivelyAgoraList from './LivelyAgoraList';
 
 const KeywordAgoraList = dynamic(() => import('./KeywordAgoraList'), {
   loading: () => (
@@ -46,7 +47,7 @@ export default function AgoraListDecider({ searchParams }: Props) {
     if (q) {
       setSearch(q);
     }
-  }, []);
+  }, [q, setSearch]);
 
   if (search) {
     return (
@@ -58,7 +59,10 @@ export default function AgoraListDecider({ searchParams }: Props) {
 
   return (
     <ErrorBoundary FallbackComponent={FallbackComponent}>
-      <CategoryAgoraList searchParams={searchParams} />
+      <>
+        {searchParams.status === 'active' && <LivelyAgoraList />}
+        <CategoryAgoraList searchParams={searchParams} />
+      </>
     </ErrorBoundary>
   );
 }

--- a/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
@@ -108,10 +108,23 @@ export default function CategoryAgoraList({ searchParams }: Props) {
   }, [selectedCategory, queryClient]);
 
   return (
-    <>
-      <div className="text-md font-semibold dark:text-dark-line-light text-left pl-10 pb-5 w-full">
-        활성화 아고라
-      </div>
+    <section
+      aria-label={
+        searchParams.status === 'active'
+          ? '활성화 아고라 리스트'
+          : '종료된 아고라 리스트'
+      }
+      className="w-full h-full"
+    >
+      {searchParams.status === 'active' && (
+        <h2
+          aria-hidden={searchParams.status === 'active'}
+          aria-label="활성화 상태 아고라"
+          className="text-md font-semibold dark:text-dark-line-light text-left pl-10 mb-16 w-full"
+        >
+          활성화 아고라
+        </h2>
+      )}
       {data?.pages[0].agoras.length < 1 ? (
         <NoAgoraMessage />
       ) : (
@@ -134,6 +147,6 @@ export default function CategoryAgoraList({ searchParams }: Props) {
           />
         </DeferredComponent>
       )}
-    </>
+    </section>
   );
 }

--- a/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
@@ -129,6 +129,7 @@ export default function CategoryAgoraList({ searchParams }: Props) {
         <NoAgoraMessage />
       ) : (
         <VirtuosoGrid
+          useWindowScroll={searchParams.status === 'active'}
           className="scrollbar-hide w-full h-full"
           data={data.pages.flatMap((page) => page.agoras)}
           totalCount={data.pages[0].agoras.length}

--- a/src/app/(main)/_components/molecules/LivelyAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/LivelyAgoraList.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import Loading from '@/app/_components/atoms/loading';
+import DeferredComponent from '@/app/_components/utils/DefferedComponent';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Agora } from '@/app/model/Agora';
+import RefreshIcon from '@/assets/icons/RefreshIcon';
+import Swiper from 'swiper';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { getLivelyAgora } from '../../_lib/getLivelyAgora';
+import NoAgoraMessage from '../atoms/NoAgoraMessage';
+import CategoryAgora from '../atoms/CategoryAgora';
+
+import 'swiper/css';
+import 'swiper/css/free-mode';
+import 'swiper/css/mousewheel';
+
+export default function LivelyAgoraList() {
+  const queryClient = useQueryClient();
+  const swiperContainerRef = useRef<HTMLDivElement>(null);
+  const [swiperInstance, setSwiperInstance] = useState<Swiper | null>(null);
+  const [isMounted, setIsMounted] = useState(false);
+  const [key, setKey] = useState(0); // 강제 리렌더링을 위한 키
+  const pathname = usePathname();
+
+  const {
+    data: agoras,
+    refetch,
+    isFetching,
+    isPending,
+  } = useQuery<Agora[], Object, Agora[], [string, string]>({
+    queryKey: ['agoras', 'lively'],
+    queryFn: getLivelyAgora,
+    retry: 2,
+    initialData: () => {
+      return queryClient.getQueryData(['agoras', 'lively']);
+    },
+  });
+
+  useEffect(() => {
+    setKey((prevKey) => prevKey + 1);
+    setIsMounted(true);
+
+    return () => {
+      setIsMounted(false);
+      if (swiperInstance && !swiperInstance.destroyed) {
+        swiperInstance.destroy();
+      }
+    };
+  }, [swiperInstance]);
+
+  useEffect(() => {
+    if (swiperInstance && !swiperInstance.destroyed) {
+      swiperInstance.destroy();
+    }
+    setSwiperInstance(null);
+    // 페이지 변경 시 key를 업데이트하여 강제 리렌더링
+    setKey((prevKey) => prevKey + 1);
+  }, [pathname, swiperInstance]);
+
+  useLayoutEffect(() => {
+    if (
+      agoras &&
+      !isFetching &&
+      isMounted &&
+      swiperContainerRef.current &&
+      !swiperInstance
+    ) {
+      setTimeout(() => {
+        const element = document.getElementById('lively-agora-swiper');
+
+        if (element) {
+          const swiper = new Swiper('.lively-agora-swiper', {
+            direction: 'horizontal',
+            loop: false,
+            centeredSlides: false,
+            touchRatio: 1,
+            freeMode: true,
+            grabCursor: true,
+            slidesPerView: 'auto',
+            spaceBetween: 10,
+            keyboard: {
+              enabled: true,
+              onlyInViewport: false,
+            },
+          });
+
+          setSwiperInstance(swiper);
+        }
+      }, 0);
+    }
+  }, [isMounted, agoras, key, swiperContainerRef, swiperInstance, isFetching]);
+
+  const refetchLivelyAgoraList = () => {
+    setSwiperInstance(null);
+    refetch();
+  };
+
+  const handleClickRefresh = () => {
+    refetchLivelyAgoraList();
+  };
+
+  const handleKeyDownRefresh = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      refetchLivelyAgoraList();
+    }
+  };
+
+  const content = () => {
+    if (isFetching || isPending) {
+      return (
+        <div className="h-36 w-full">
+          <DeferredComponent>
+            <Loading
+              w="32"
+              h="32"
+              className="m-5 flex justify-center items-center"
+            />
+          </DeferredComponent>
+        </div>
+      );
+    }
+    if (!agoras || agoras.length < 1) {
+      return <NoAgoraMessage />;
+    }
+    return (
+      isMounted &&
+      agoras.length > 0 && (
+        <div className="w-full px-0.5rem pb-32 flex overflow-hidden ml-5">
+          <div
+            key={key}
+            id="lively-agora-swiper"
+            ref={swiperContainerRef}
+            className="lively-agora-swiper pr-1rem w-full h-full"
+          >
+            <div className="swiper-wrapper h-full">
+              {agoras.map((agora) => (
+                <div key={agora.id} className="swiper-slide h-full">
+                  <CategoryAgora agora={agora} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )
+    );
+  };
+
+  return (
+    <section aria-label="인기 아고라 리스트" className="w-full h-1/2">
+      <h2
+        aria-label="실시간 인기 아고라"
+        className="flex justify-between items-center gap-x-6 text-md font-semibold dark:text-dark-line-light text-left pl-10 w-full mb-16 mt-7"
+      >
+        🔥 실시간 HOT 아고라
+        <button
+          type="button"
+          aria-label="활발한 아고라 다시 불러오기"
+          onClick={handleClickRefresh}
+          onKeyDown={handleKeyDownRefresh}
+          className="cursor-pointer flex font-normal mr-5"
+        >
+          <span className="text-xs mr-5 text-athens-sub">새로고침</span>
+          <RefreshIcon className="w-16 h-16" fill="#FEAC3E" />
+        </button>
+      </h2>
+      {content()}
+    </section>
+  );
+}

--- a/src/app/(main)/_components/molecules/LivelyAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/LivelyAgoraList.tsx
@@ -39,7 +39,7 @@ export default function LivelyAgoraList() {
   });
 
   useEffect(() => {
-    setKey((prevKey) => prevKey + 1);
+    // setKey((prevKey) => prevKey + 1);
     setIsMounted(true);
 
     return () => {
@@ -54,10 +54,10 @@ export default function LivelyAgoraList() {
     if (swiperInstance && !swiperInstance.destroyed) {
       swiperInstance.destroy();
     }
-    setSwiperInstance(null);
     // 페이지 변경 시 key를 업데이트하여 강제 리렌더링
     setKey((prevKey) => prevKey + 1);
-  }, [pathname, swiperInstance]);
+    setSwiperInstance(null);
+  }, [pathname]);
 
   useLayoutEffect(() => {
     if (
@@ -110,7 +110,7 @@ export default function LivelyAgoraList() {
   const content = () => {
     if (isFetching || isPending) {
       return (
-        <div className="h-36 w-full">
+        <div className="h-235 w-full">
           <DeferredComponent>
             <Loading
               w="32"

--- a/src/app/(main)/_components/organisms/AgoraListDeciderHydration.tsx
+++ b/src/app/(main)/_components/organisms/AgoraListDeciderHydration.tsx
@@ -8,6 +8,7 @@ import { SearchParams } from '@/app/model/Agora';
 import { getAgoraCategorySearch } from '../../_lib/getAgoraCategorySearch';
 import AgoraListDecider from '../molecules/AgoraListDecider';
 import { getAgoraKeywordSearch } from '../../_lib/getAgoraKeywordSearch';
+import { getLivelyAgora } from '../../_lib/getLivelyAgora';
 
 type Props = {
   searchParams: SearchParams;
@@ -18,6 +19,7 @@ export default async function AgoraListDeciderHydration({
 }: Props) {
   const queryClient = new QueryClient();
   const isSearch = searchParams.q;
+
   await queryClient.prefetchInfiniteQuery({
     queryKey: [
       'agoras',
@@ -28,6 +30,12 @@ export default async function AgoraListDeciderHydration({
     queryFn: isSearch ? getAgoraKeywordSearch : getAgoraCategorySearch,
     initialPageParam: { nextCursor: null },
   });
+
+  await queryClient.prefetchQuery({
+    queryKey: ['agoras', 'lively'],
+    queryFn: getLivelyAgora,
+  });
+
   const dehydratedState = dehydrate(queryClient);
 
   return (

--- a/src/app/(main)/_components/templates/Main.tsx
+++ b/src/app/(main)/_components/templates/Main.tsx
@@ -16,7 +16,7 @@ export default function Main({ searchParams }: Props) {
     <main className="justify-center items-stretch flex flex-col h-dvh flex-1 relative">
       <section
         aria-label="아고라 리스트"
-        className="flex flex-1 flex-col p-5 pt-3 pb-5rem justify-start items-center"
+        className="flex h-full flex-col p-5 pt-3 pb-5rem justify-start items-center"
       >
         <Suspense
           fallback={

--- a/src/app/(main)/_lib/getLivelyAgora.ts
+++ b/src/app/(main)/_lib/getLivelyAgora.ts
@@ -1,0 +1,29 @@
+import fetchWrapper from '@/lib/fetchWrapper';
+import showToast from '@/utils/showToast';
+
+// eslint-disable-next-line import/prefer-default-export
+export const getLivelyAgora = async () => {
+  const res = await fetchWrapper.call('/api/v1/open/agoras/active', {
+    next: {
+      tags: ['agoras', 'lively'],
+    },
+    credentials: 'include',
+    cache: 'no-cache',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (res.success === false) {
+    if (res.error.code === 1002) {
+      showToast('잘못된 요청입니다.', 'error');
+    }
+  }
+
+  if (res.response.agoras) {
+    return res.response.agoras;
+  }
+
+  // 인기 아고라가 없을 땐 빈 배열 반환
+  return res.response;
+};

--- a/src/app/_components/molecules/AgoraImageUpload.tsx
+++ b/src/app/_components/molecules/AgoraImageUpload.tsx
@@ -146,7 +146,7 @@ export default function AgoraImageUpload({ image }: Props) {
               aria-hidden
               className="flex justify-center items-center h-full w-full bg-dark-light-500 rounded-3xl under-mobile:rounded-2xl"
             >
-              <ImageIcon className="w-12 h-12" />
+              <ImageIcon className="w-22 h-22" />
             </div>
           )}
           <input

--- a/src/app/model/Agora.ts
+++ b/src/app/model/Agora.ts
@@ -19,6 +19,7 @@ export interface ClosedAgora {
   agoraColor: string;
   prosCount: number;
   consCount: number;
+  totalMember: number;
   createdAt: string;
   status: string;
 }


### PR DESCRIPTION
### 🔗 Linked Issue

- [ ] #81 
- [ ] #82 

### 🛠 개발 기능

- 종료된 아고라 투표 결과 텍스트가 아닌 그래프로 표현
- 인기 아고라 swiper로 구현

### 🧩 해결 방법

- 그래프는 너비의 퍼센트(%)를 사용하여 찬/반 표현하였습니다.

- 인기 아고라 페이지가 `shallow routing`을 사용하고 있어 dom unmount가 되지 않아 swiper가 처음 새로고침시에만 동작합니다.
이는 swiper가 적용될 태그에 key 값을 주고 다른 페이지에서 넘어오는 등의 dom unmount 및 update가 필요할 땐 key 값을 다르게 주어 강제 리렌더링을 시켜주도록 하여 해결하였습니다.

### 🔍 리뷰 포인트

- 리뷰 시 어떤 부분에 집중해야 할지 명시해주세요.

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
