### PR TITLE
fix: 채팅방에서 messages.length 출력되는 문제 수정

### DIFF
--- a/src/app/(chat)/_components/molecules/Message.tsx
+++ b/src/app/(chat)/_components/molecules/Message.tsx
@@ -280,7 +280,7 @@ export default function Message() {
   return (
     <div key={agoraId} ref={listRef} className="overflow-y-auto flex-1">
       {!adjustScroll && pageRendered && <div ref={ref} className="h-1" />}
-      {messages.length &&
+      {messages.length > 0 &&
         messages.map((message, idx) => (
           <div key={message.chatId || Math.random()}>
             <MessageItem


### PR DESCRIPTION
### 🔗 Linked Issue

### 🛠 개발 기능

- 채팅방 message.length로 메시지 존재 여부 확인하던 것을 비교 연산자 추가함

### 🧩 해결 방법

- 

### 🔍 리뷰 포인트

- 

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
