### PR TITLE
클라이언트에서 서버 코드 호출로 인한 버그 수정

### DIFF
--- a/public/custom-sw.js
+++ b/public/custom-sw.js
@@ -1,100 +1,62 @@
-const DB_NAME = 'TabDatabase';
-const STORE_NAME = 'Tabs';
+const INVALID_JWT_TOKEN = 'Invalid JWT token.';
+const TOKEN_EXPIRED = 'The token has expired.';
+const INVALID_JWT_SIGNATURE = 'Invalid JWT signature.';
+const INVALID_AUTHORIZATION_HEADER =
+  'Authorization header is missing or does not start with Bearer';
+const UNSUPPORTED_JWT = 'Unsupported JWT token.';
 
-function openDB() {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, 1);
-    request.onupgradeneeded = (event) => {
-      const db = event.target.result;
-      if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME, { keyPath: 'id' });
-      }
-    };
-    request.onsuccess = (event) => {
-      resolve(event.target.result);
-    };
-    request.onerror = (event) => {
-      reject(event.target.error);
-    };
-  });
-}
+const AUTH_MESSAGE = [
+  INVALID_JWT_TOKEN,
+  TOKEN_EXPIRED,
+  INVALID_JWT_SIGNATURE,
+  INVALID_AUTHORIZATION_HEADER,
+  UNSUPPORTED_JWT,
+];
 
-async function getTabIds() {
-  const db = await openDB();
-  const transaction = db.transaction(STORE_NAME, 'readonly');
-  const store = transaction.objectStore(STORE_NAME);
-  return new Promise((resolve, reject) => {
-    const request = store.getAll();
-    request.onsuccess = () => {
-      resolve(request.result);
-    };
-    request.onerror = () => {
-      reject(request.error);
-    };
-  });
-}
-
-function transactionComplete(transaction) {
-  return new Promise((resolve, reject) => {
-    transaction.oncomplete = () => {
-      resolve();
-    };
-    transaction.onerror = (event) => {
-      reject(event.target.error);
-    };
-    transaction.onabort = (event) => {
-      reject(event.target.error);
-    };
-  });
-}
-
-let baseUrl = '';
-let voteType = '';
-let tabVotes = {};
-
-const tokenErrorHandler = async (response, baseUrl) => {
-  const { error } = response;
-  switch (error.code) {
-    case 1002:
-      fetch(`${baseUrl}/api/v1/reissue`, {
-        method: 'POST',
-        credentials: 'include',
-      }).then((res) => {
-        if (!res.ok) {
-          // console.log(res);
-        } else {
-          reissueToken = res.json().accessToken;
-        }
-      });
-      break;
-    case 1201:
-      fetch(`${baseUrl}/api/v1/temp-user`, {
-        method: 'POST',
-        credentials: 'include',
-      }).then((res) => {
-        if (!res.ok) {
-          // console.log(res);
-        } else {
-          reissueToken = res.json().response.accessToken;
-        }
-      });
-      break;
-    default:
-      break;
-  }
+let newAccessToken = '';
+const voteType = {
+  type: 'DEFAULT',
 };
 
-const call = async (url, fetchNext, retry = 3) => {
+const tokenErrorHandler = async (baseUrl) => {
+  fetch(`${baseUrl}/api/v1/reissue`, {
+    method: 'POST',
+    credentials: 'include',
+  }).then((res) => {
+    if (!res.ok) {
+      this.clients.matchAll().then((clients) => {
+        clients.forEach((client) => {
+          client.postMessage({
+            action: 'fetchError',
+            message: 'signin required',
+          });
+        });
+      });
+    } else {
+      newAccessToken = res.json().accessToken;
+    }
+  });
+};
+
+const call = async (baseUrl, url, fetchNext, retry = 3) => {
   const response = await fetch(url, fetchNext);
 
   if (!response.ok) {
     const res = await response.json();
+
     // 인증 자격에 관한 오류 처리
-    if (response.status === 401) {
-      await tokenErrorHandler(res);
+    if (response.error && AUTH_MESSAGE.includes(response.error.message)) {
+      await tokenErrorHandler(baseUrl);
       // 재발급 후 재요청
       if (retry !== 0) {
-        call(url, fetchNext, retry - 1);
+        const newFetchNext = {
+          ...fetchNext,
+          headers: {
+            ...fetchNext.headers,
+            Authorization: `Bearer ${newAccessToken}`,
+          },
+        };
+        call(baseUrl, url, newFetchNext, retry - 1);
       }
     } else {
       // 인증 외 오류는 호출한 곳에서 처리
@@ -106,48 +68,26 @@ const call = async (url, fetchNext, retry = 3) => {
   return result;
 };
 
-async function loadTabVotesFromDB() {
-  const tabIds = await getTabIds();
-  tabIds.forEach((tab) => {
-    tabVotes[tab.id] = { voteType: '' };
-  });
-}
-
-self.addEventListener('install', (event) => {
-  self.skipWaiting();
+this.addEventListener('install', () => {
+  this.skipWaiting();
 });
 
-self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim());
+this.addEventListener('activate', (event) => {
+  event.waitUntil(this.clients.claim());
 });
 
-self.addEventListener('message', async (event) => {
+this.addEventListener('message', async (event) => {
   const { action, data } = event.data;
 
-  if (action === 'initialize') {
-    if (event.data.baseUrl) {
-      baseUrl = event.data.baseUrl;
-    }
-
-    if (!Object.keys(tabVotes).length) {
-      await loadTabVotesFromDB();
-    }
-
-    tabVotes = {
-      ...tabVotes,
-      [event.data.tabId]: { voteType: '' },
-    };
-  }
-
   if (action === 'updateVote') {
-    tabVotes[event.data.tabId].voteType = data.voteType;
+    voteType.type = data.voteType;
   }
 
   if (action === 'startTimer') {
-    // Set a timeout to send the POST request after 15 seconds
     const voteDuration = data.voteEndTime - new Date().getTime();
     setTimeout(async () => {
-      const res = await call(
+      const voteRes = await call(
+        data.baseUrl,
         `${data.baseUrl}/api/v1/auth/agoras/${data.agoraId}/vote`,
         {
           method: 'PATCH',
@@ -156,36 +96,36 @@ self.addEventListener('message', async (event) => {
             Authorization: `Bearer ${data.token}`,
           },
           body: JSON.stringify({
-            voteType: tabVotes[event.data.tabId].voteType || 'DEFAULT',
+            voteType: voteType.type || 'DEFAULT',
             isOpinionVoted: 'true',
           }),
         },
       );
 
-      if (res.success === false) {
+      if (voteRes.success === false) {
         event.source.postMessage({
           action: 'fetchError',
-          message: res.error,
-          tabId: event.data.tabId,
+          message: voteRes.error,
         });
       } else {
-        const result = res.response;
-        self.clients.matchAll().then((clients) => {
+        const result = voteRes.response;
+        this.clients.matchAll().then((clients) => {
           clients.forEach((client) => {
             client.postMessage({
               action: 'voteSent',
               data: result,
-              tabId: event.data.tabId,
+              newAccessToken,
             });
           });
         });
       }
 
-      tabVotes[event.data.tabId].voteType = '';
+      voteType.type = 'DEFAULT';
 
       // Set another timeout to send the GET request after an additional 5 seconds
       setTimeout(async () => {
-        const res = await call(
+        const voteResultRes = await call(
+          data.baseUrl,
           `${data.baseUrl}/api/v1/auth/agoras/${data.agoraId}/results`,
           {
             method: 'GET',
@@ -196,22 +136,21 @@ self.addEventListener('message', async (event) => {
           },
         );
 
-        if (res.success === false) {
+        if (voteResultRes.success === false) {
           // console.log('Error fetching vote result:', res.error)
           event.source.postMessage({
             action: 'fetchError',
-            message: res.error,
-            tabId: event.data.tabId,
+            message: voteResultRes.error,
           });
         } else {
-          const result = res.response;
-          self.clients.matchAll().then((clients) => {
+          const result = voteResultRes.response;
+          this.clients.matchAll().then((clients) => {
             // console.log('Sending vote result:', result);
             clients.forEach((client) => {
               client.postMessage({
                 action: 'voteResult',
                 result,
-                tabId: event.data.tabId,
+                newAccessToken,
               });
             });
           });

--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -10,7 +10,6 @@ import { AgoraMeta } from '@/app/model/AgoraMeta';
 import { useChatInfo } from '@/store/chatInfo';
 import showToast from '@/utils/showToast';
 import { useVoteStore } from '@/store/vote';
-import getToken from '@/lib/getToken';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import getKey from '@/utils/getKey';
 import { getAgoraUserListQueryKey } from '@/constants/queryKey';
@@ -185,7 +184,7 @@ export default function Header() {
 
   const subscribeErrorControl = async (err: any) => {
     if (err.code === 1201) {
-      await getToken();
+      // await getToken();
     } else if (err.code === 1003) {
       const reissuResult = await callReissueFn();
       if (reissuResult === AUTHORIZATION_FAIL) {

--- a/src/app/(chat)/_lib/getAgoraUsers.ts
+++ b/src/app/(chat)/_lib/getAgoraUsers.ts
@@ -7,6 +7,7 @@ import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { AGORA_USER } from '@/constants/responseErrorMessage';
+import isNull from '@/utils/isNull';
 
 export const getAgoraUsers: QueryFunction<
   AgoraUserProfileType[],
@@ -15,7 +16,7 @@ export const getAgoraUsers: QueryFunction<
   const [_1, _2, agoraId] = queryKey;
 
   const session = await getSession();
-  if (!session) {
+  if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 

--- a/src/app/(chat)/_lib/getChatMessages.ts
+++ b/src/app/(chat)/_lib/getChatMessages.ts
@@ -5,6 +5,7 @@ import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { CHAT_MESSAGE } from '@/constants/responseErrorMessage';
+import isNull from '@/utils/isNull';
 
 type Meta = {
   key: number | null;
@@ -32,7 +33,7 @@ export const getChatMessages: QueryFunction<
   const urlSearchParams = new URLSearchParams(Object.entries(searchParams));
 
   const session = await getSession();
-  if (!session) {
+  if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 

--- a/src/app/(chat)/_lib/getVoteResult.ts
+++ b/src/app/(chat)/_lib/getVoteResult.ts
@@ -6,6 +6,7 @@ import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { VOTE_RESULT } from '@/constants/responseErrorMessage';
+import isNull from '@/utils/isNull';
 
 type VoteResult = {
   id: number;
@@ -20,7 +21,7 @@ export const getVoteResult: QueryFunction<
   const [_1, agoraId] = queryKey;
 
   const session = await getSession();
-  if (!session) {
+  if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 

--- a/src/app/(chat)/_lib/patchAgoraEnd.ts
+++ b/src/app/(chat)/_lib/patchAgoraEnd.ts
@@ -2,10 +2,11 @@ import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { AGORA_END } from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
+import isNull from '@/utils/isNull';
 
 export const patchAgoraEnd = async (agoraId: number) => {
   const session = await getSession();
-  if (!session) {
+  if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 

--- a/src/app/(chat)/_lib/patchAgoraImg.ts
+++ b/src/app/(chat)/_lib/patchAgoraImg.ts
@@ -3,6 +3,7 @@ import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { AGORA_IMAGE_UPDATE } from '@/constants/responseErrorMessage';
+import isNull from '@/utils/isNull';
 
 type Props = {
   agoraId: number;
@@ -11,7 +12,7 @@ type Props = {
 
 export const patchAgoraImg = async ({ agoraId, fileUrl }: Props) => {
   const session = await getSession();
-  if (!session) {
+  if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 

--- a/src/app/(chat)/_lib/patchAgoraStart.ts
+++ b/src/app/(chat)/_lib/patchAgoraStart.ts
@@ -2,10 +2,11 @@ import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { AGORA_START } from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
+import isNull from '@/utils/isNull';
 
 export const patchAgoraStart = async (agoraId: number) => {
   const session = await getSession();
-  if (!session) {
+  if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 

--- a/src/app/(chat)/_lib/patchAgoraTimeOut.ts
+++ b/src/app/(chat)/_lib/patchAgoraTimeOut.ts
@@ -2,10 +2,11 @@ import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { AGORA_TIME_OUT } from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
+import isNull from '@/utils/isNull';
 
 export const patchAgoraTimeOut = async (agoraId: number) => {
   const session = await getSession();
-  if (!session) {
+  if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 

--- a/src/app/(chat)/_lib/patchChatExit.ts
+++ b/src/app/(chat)/_lib/patchChatExit.ts
@@ -25,9 +25,7 @@ const patchChatExit = async ({ agoraId }: Props) => {
     },
   });
 
-  console.log('res', res);
   if (!res.ok && !res.success) {
-    console.log('res.error', res.error);
     if (!res.error) {
       throw new Error(AGORA_EXIT.UNKNOWN_ERROR);
     }

--- a/src/app/(chat)/_lib/patchChatExit.ts
+++ b/src/app/(chat)/_lib/patchChatExit.ts
@@ -2,6 +2,7 @@ import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { AGORA_EXIT } from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
+import isNull from '@/utils/isNull';
 
 type Props = {
   agoraId: number;
@@ -9,7 +10,7 @@ type Props = {
 
 const patchChatExit = async ({ agoraId }: Props) => {
   const session = await getSession();
-  if (!session) {
+  if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 

--- a/src/app/(chat)/_lib/postFilterBadWords.ts
+++ b/src/app/(chat)/_lib/postFilterBadWords.ts
@@ -2,6 +2,7 @@ import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { FILTER_BAD_WORDS } from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
+import isNull from '@/utils/isNull';
 
 type Props = {
   message: string;
@@ -10,7 +11,7 @@ type Props = {
 
 const postFilterBadWords = async ({ message, agoraId }: Props) => {
   const session = await getSession();
-  if (!session) {
+  if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 

--- a/src/app/(chat)/agoras/[agora]/page.tsx
+++ b/src/app/(chat)/agoras/[agora]/page.tsx
@@ -8,7 +8,6 @@ export async function generateMetadata() {
   const agoraId = headers().get('referer')?.split('/').pop();
   let agoraTitle = '';
 
-  console.log('agoraId', agoraId);
   const res = await callFetchWrapper(`/api/v1/open/agoras/${agoraId}/title`, {
     next: {
       tags: getSelectedAgoraTags(agoraId as string),

--- a/src/app/(main)/_components/organisms/EnterAgoraContent.tsx
+++ b/src/app/(main)/_components/organisms/EnterAgoraContent.tsx
@@ -7,7 +7,6 @@ import Loading from '@/app/_components/atoms/loading';
 import { usePathname, useRouter } from 'next/navigation';
 import { getSelectedAgoraQueryKey } from '@/constants/queryKey';
 import { homeSegmentKey } from '@/constants/segmentKey';
-import showToast from '@/utils/showToast';
 import { getAgoraTitle } from '../../_lib/getAgoraTitle';
 import ModalPosSelectContainer from '../../flow/enter-agora/_components/ModalPosSelectContainer';
 import InputErrorMessage from '../../flow/enter-agora/_components/InputErrorMessage';
@@ -19,7 +18,6 @@ export default function EnterAgoraContent() {
   const router = useRouter();
   const pathname = usePathname();
   const agoraId = pathname.split('/')[3];
-
   const shouldFetch = !!agoraId && !selectedAgora.id;
 
   const { data, isSuccess, isError } = useQuery({
@@ -38,7 +36,7 @@ export default function EnterAgoraContent() {
         agoraColor: data.agoraColor,
       });
     } else if (!isSuccess && isError) {
-      showToast('아고라 제목을 불러오는데 실패했습니다.', 'error');
+      // showToast('아고라 제목을 불러오는데 실패했습니다.', 'error');
       router.push(`${homeSegmentKey}?status=active`);
     }
   }, [

--- a/src/app/(main)/_lib/getAgoraTitle.ts
+++ b/src/app/(main)/_lib/getAgoraTitle.ts
@@ -11,7 +11,6 @@ export const getAgoraTitle: QueryFunction<
 > = async ({ queryKey }) => {
   const [_, agoraId] = queryKey;
 
-  console.log('agoraId', agoraId);
   const res = await callFetchWrapper(`/api/v1/open/agoras/${agoraId}/title`, {
     next: {
       tags: getSelectedAgoraTags(agoraId),

--- a/src/app/(main)/_lib/postCreateAgora.ts
+++ b/src/app/(main)/_lib/postCreateAgora.ts
@@ -4,6 +4,7 @@ import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import { AUTH_MESSAGE, SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { AGORA_CREATE } from '@/constants/responseErrorMessage';
+import isNull from '@/utils/isNull';
 
 const TITLE_NULL = { title: '공백일 수 없습니다' };
 const CATEGORY_ERROR = { capacity: '1 이상이어야 합니다' };
@@ -37,7 +38,7 @@ export const postCreateAgora = async (info: AgoraConfig) => {
   formData.append('file', file);
 
   const session = await getSession();
-  if (!session) {
+  if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 

--- a/src/app/(main)/_lib/postEnterAgoraInfo.ts
+++ b/src/app/(main)/_lib/postEnterAgoraInfo.ts
@@ -4,6 +4,7 @@ import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { SIGNIN_REQUIRED, TOKEN_EXPIRED } from '@/constants/authErrorMessage';
 import { getSession } from '@/serverActions/auth';
 import { AGORA_ENTER } from '@/constants/responseErrorMessage';
+import isNull from '@/utils/isNull';
 
 type Props = {
   info: {
@@ -23,7 +24,7 @@ const splitMessage = (message: string) => {
 
 export const postEnterAgoraInfo = async ({ info, agoraId }: Props) => {
   const session = await getSession();
-  if (!session) {
+  if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 

--- a/src/app/(main)/_lib/postEnterAgoraInfo.ts
+++ b/src/app/(main)/_lib/postEnterAgoraInfo.ts
@@ -88,7 +88,6 @@ export const postEnterAgoraInfo = async ({ info, agoraId }: Props) => {
     // return null;
   }
 
-  console.log('post enter aogra into res', res);
   const result = res.response;
 
   return result;

--- a/src/app/(main)/flow/enter-agora/_components/EnterAgoraButton.tsx
+++ b/src/app/(main)/flow/enter-agora/_components/EnterAgoraButton.tsx
@@ -45,7 +45,7 @@ export default function EnterAgoraButton() {
 
   const mutation = useMutation({
     mutationFn: callEnterAgoraAPI,
-    onSuccess: (response) => {
+    onSuccess: async (response) => {
       if (response) {
         if (response === AGORA_STATUS.CLOSED) {
           showToast('종료된 아고라입니다.', 'info');
@@ -77,12 +77,12 @@ export default function EnterAgoraButton() {
         routePage();
       } else {
         setIsLoading(false);
-        handleError(new Error('입장 실패했습니다.\n 다시 시도해주세요.'));
+        await handleError(new Error('입장 실패했습니다.\n 다시 시도해주세요.'));
       }
     },
-    onError: (error) => {
+    onError: async (error) => {
       setIsLoading(false);
-      handleError(error);
+      await handleError(error);
     },
   });
 

--- a/src/app/config/RQProvider.tsx
+++ b/src/app/config/RQProvider.tsx
@@ -38,7 +38,9 @@ export default function RQProvider({ children }: Props) {
         },
       },
       queryCache: new QueryCache({
-        onError: (error) => handleError(error),
+        onError: async (error) => {
+          await handleError(error);
+        },
       }),
     }),
   );

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,5 +1,6 @@
 import type { NextAuthConfig, User } from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
+import isNull from './utils/isNull';
 
 interface Authorize {
   accessToken?: string;
@@ -125,7 +126,7 @@ export const authConfig: NextAuthConfig = {
         const { search, origin, pathname } = new URL(url);
         const callbackUrl = new URLSearchParams(search).get('callbackUrl');
 
-        if (callbackUrl) {
+        if (!isNull(callbackUrl)) {
           return callbackUrl.startsWith('/')
             ? `${baseUrl}${callbackUrl}`
             : callbackUrl;

--- a/src/hooks/useApiError.ts
+++ b/src/hooks/useApiError.ts
@@ -2,7 +2,6 @@
 
 import showToast from '@/utils/showToast';
 import { signOut } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import {
   AUTHORIZATION_FAIL,
@@ -10,16 +9,11 @@ import {
   SIGNIN_REQUIRED,
 } from '@/constants/authErrorMessage';
 import { UseMutateFunction } from '@tanstack/react-query';
+import isNull from '@/utils/isNull';
 import useUpdateSession from './useUpdateSession';
 
 const useApiError = () => {
-  const router = useRouter();
   const { callReissueFn } = useUpdateSession();
-
-  const signOutUser = useCallback(() => {
-    signOut();
-    router.replace('/');
-  }, [router]);
 
   const authErrorHandlers = useCallback(
     async (callback?: UseMutateFunction<any, Error, void, unknown>) => {
@@ -30,14 +24,14 @@ const useApiError = () => {
           '로그인 세션이 만료되었습니다. 다시 로그인 해주세요.',
           'error',
         );
-        signOutUser();
+        signOut();
       }
 
-      if (callback) {
+      if (!isNull(callback)) {
         callback();
       }
     },
-    [callReissueFn, signOutUser],
+    [callReissueFn],
   );
 
   const handleError = useCallback(
@@ -51,7 +45,7 @@ const useApiError = () => {
           await authErrorHandlers(callback);
         } else if (error.message === SIGNIN_REQUIRED) {
           showToast('로그인이 필요합니다.', 'error');
-          signOutUser();
+          signOut();
         } else if (response.status === 500) {
           showToast(
             '서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.',
@@ -62,7 +56,7 @@ const useApiError = () => {
         }
       }
     },
-    [authErrorHandlers, signOutUser],
+    [authErrorHandlers],
   );
 
   return { handleError };

--- a/src/hooks/useApiError.ts
+++ b/src/hooks/useApiError.ts
@@ -1,50 +1,57 @@
+'use client';
+
+import showToast from '@/utils/showToast';
+import { signOut } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import { useCallback } from 'react';
 import {
   AUTHORIZATION_FAIL,
   AUTH_MESSAGE,
   SIGNIN_REQUIRED,
 } from '@/constants/authErrorMessage';
-import { getReissuanceToken } from '@/lib/getReissuanceToken';
-import showToast from '@/utils/showToast';
-import { signOut } from 'next-auth/react';
-import { redirect } from 'next/navigation';
-import { useCallback } from 'react';
+import { UseMutateFunction } from '@tanstack/react-query';
+import useUpdateSession from './useUpdateSession';
 
 const useApiError = () => {
-  const signOutUser = useCallback(async () => {
-    await signOut();
-    redirect('/');
-  }, []);
+  const router = useRouter();
+  const { callReissueFn } = useUpdateSession();
 
-  const authErrorHandlers = useCallback(async () => {
-    try {
-      const reissueResponse = await getReissuanceToken();
+  const signOutUser = useCallback(() => {
+    signOut();
+    router.replace('/');
+  }, [router]);
+
+  const authErrorHandlers = useCallback(
+    async (callback?: UseMutateFunction<any, Error, void, unknown>) => {
+      const reissueResponse = await callReissueFn();
 
       if (reissueResponse === AUTHORIZATION_FAIL) {
-        console.log('useApiError에서의 세션 만료 메시지', reissueResponse);
         showToast(
           '로그인 세션이 만료되었습니다. 다시 로그인 해주세요.',
           'error',
         );
-        await signOutUser();
+        signOutUser();
       }
-      console.log('useApiError에서의 세션 만료 메시지', reissueResponse);
-      showToast('세션 발급 완료', 'success');
-      // else if (reissueResponse === AUTHORIZATION_SUCCESS) {
-      // }
-    } catch (error) {
-      console.log('useApi Auth Error Catch', error);
-    }
-  }, [signOutUser]);
+
+      if (callback) {
+        callback();
+      }
+    },
+    [callReissueFn, signOutUser],
+  );
 
   const handleError = useCallback(
-    async (error: Error) => {
+    async (
+      error: Error,
+      callback?: UseMutateFunction<any, Error, void, unknown>,
+    ) => {
       const response = error as any;
       if (error instanceof Error) {
         if (AUTH_MESSAGE.includes(error.message)) {
-          await authErrorHandlers();
+          await authErrorHandlers(callback);
         } else if (error.message === SIGNIN_REQUIRED) {
           showToast('로그인이 필요합니다.', 'error');
-          await signOutUser();
+          signOutUser();
         } else if (response.status === 500) {
           showToast(
             '서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.',
@@ -55,7 +62,7 @@ const useApiError = () => {
         }
       }
     },
-    [authErrorHandlers],
+    [authErrorHandlers, signOutUser],
   );
 
   return { handleError };

--- a/src/hooks/useUpdateSession.ts
+++ b/src/hooks/useUpdateSession.ts
@@ -3,13 +3,14 @@ import {
   AUTHORIZATION_SUCCESS,
 } from '@/constants/authErrorMessage';
 import { getReissuanceToken } from '@/lib/getReissuanceToken';
+import isNull from '@/utils/isNull';
 import { useSession } from 'next-auth/react';
 
 const useUpdateSession = () => {
   const { data: session, update } = useSession();
 
   const callReissueFn = async () => {
-    if (!session) {
+    if (isNull(session)) {
       return AUTHORIZATION_FAIL;
     }
 

--- a/src/hooks/useUpdateSession.ts
+++ b/src/hooks/useUpdateSession.ts
@@ -1,0 +1,34 @@
+import {
+  AUTHORIZATION_FAIL,
+  AUTHORIZATION_SUCCESS,
+} from '@/constants/authErrorMessage';
+import { getReissuanceToken } from '@/lib/getReissuanceToken';
+import { useSession } from 'next-auth/react';
+
+const useUpdateSession = () => {
+  const { data: session, update } = useSession();
+
+  const callReissueFn = async () => {
+    if (!session) {
+      return AUTHORIZATION_FAIL;
+    }
+
+    const result = await getReissuanceToken(session.user.accessToken);
+    if (!result.success) {
+      return AUTHORIZATION_FAIL;
+    }
+    update({
+      ...session,
+      user: {
+        ...session.user,
+        accessToken: result.newAccessToken,
+      },
+    });
+
+    return AUTHORIZATION_SUCCESS;
+  };
+
+  return { callReissueFn };
+};
+
+export default useUpdateSession;

--- a/src/hooks/useVote.tsx
+++ b/src/hooks/useVote.tsx
@@ -1,4 +1,3 @@
-import swManager from '@/utils/swManager';
 import { useEffect, useState } from 'react';
 
 const useVote = () => {
@@ -9,7 +8,6 @@ const useVote = () => {
       navigator.serviceWorker.controller.postMessage({
         action: 'updateVote',
         data: vote,
-        tabId: swManager.getTabId(),
       });
     }
   }, [vote]);

--- a/src/lib/fetchWrapper.ts
+++ b/src/lib/fetchWrapper.ts
@@ -19,14 +19,11 @@ export class FetchWrapper {
         ...fetchNext,
         headers: {
           ...fetchNext.headers,
-          // Connection: 'keep-alive',
         },
       });
 
       return await response.json();
     } catch (error) {
-      console.log('error', error);
-      console.log('response', response);
       throw new Error('알 수 없는 에러가 발생했습니다.');
     }
   }

--- a/src/lib/getReissuanceToken.ts
+++ b/src/lib/getReissuanceToken.ts
@@ -1,38 +1,26 @@
-import { getSession, updateSession } from '@/serverActions/auth';
-import {
-  AUTHORIZATION_FAIL,
-  AUTHORIZATION_SUCCESS,
-} from '@/constants/authErrorMessage';
 import { callFetchWrapper } from './fetchWrapper';
 
-export const getReissuanceToken = async () => {
-  const session = await getSession();
-  if (!session) {
-    return AUTHORIZATION_FAIL;
-  }
-
+export const getReissuanceToken = async (token: string) => {
   const res = await callFetchWrapper('/api/v1/auth/reissue', {
     method: 'POST',
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${session.user.accessToken}`,
+      Authorization: `Bearer ${token}`,
     },
   });
-
-  console.log('res', res);
 
   if (!res.ok && !res.success) {
     // 토큰 재발급 실패
     // 토큰 재발급이 실패하면 로그아웃 처리
-    return AUTHORIZATION_FAIL;
+    return {
+      success: false,
+      newAccessToken: null,
+    };
   }
 
-  try {
-    await updateSession(res.response);
-    // await updateSession(res.response);
-  } catch (error) {
-    console.log('jwt update error', error);
-  }
-  return AUTHORIZATION_SUCCESS;
+  return {
+    success: true,
+    newAccessToken: res.response,
+  };
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,40 +1,15 @@
 // middleware.ts
-import { NextRequest, NextResponse } from 'next/server';
-import tokenManager from './utils/tokenManager';
+import { NextResponse } from 'next/server';
 import { getSession } from './serverActions/auth';
 
-export async function middleware(request: NextRequest) {
+export async function middleware() {
   const session = await getSession();
 
   if (!session) {
     return NextResponse.redirect(`${process.env.NEXT_CLIENT_URL}/`);
   }
 
-  const requestHeaders = new Headers(request.headers);
-  requestHeaders.set('x-pathname', request.nextUrl.pathname);
-  // 공유를 통해 들어온 유저는 referer가 없기 때문에
-  // referer가 없으며 nextUrl.pathname이 agoras로 시작하면 토큰이 있는지 확인하고 없으면 입장하기 모달 페이지로 이동
-  if (
-    request.headers.get('referer') === null &&
-    request.nextUrl.pathname.split('/')[1] === 'agoras'
-  ) {
-    const refererPathname = request.nextUrl.pathname;
-    const agoraId = refererPathname.split('/')[2];
-
-    const token = tokenManager.getToken();
-
-    if (!token) {
-      return NextResponse.redirect(
-        `${process.env.NEXT_CLIENT_URL}/flow/enter-agora/${agoraId}`,
-      );
-    }
-  }
-
-  return NextResponse.next({
-    request: {
-      headers: requestHeaders,
-    },
-  });
+  return NextResponse.next();
 }
 
 export const config = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,12 @@
 // middleware.ts
 import { NextResponse } from 'next/server';
 import { getSession } from './serverActions/auth';
+import isNull from './utils/isNull';
 
 export async function middleware() {
   const session = await getSession();
 
-  if (!session) {
+  if (isNull(session)) {
     return NextResponse.redirect(`${process.env.NEXT_CLIENT_URL}/`);
   }
 

--- a/src/serverActions/auth.ts
+++ b/src/serverActions/auth.ts
@@ -45,7 +45,6 @@ export const getSession = async () => {
 };
 
 export const updateSession = async (session: string) => {
-  console.log('session', session);
   await update({
     user: {
       accessToken: session,

--- a/src/utils/isNull.ts
+++ b/src/utils/isNull.ts
@@ -1,0 +1,11 @@
+export default function isNull(
+  value: any,
+): value is null | undefined | '' | 'null' | 'undefined' {
+  return (
+    value === null ||
+    value === undefined ||
+    value === '' ||
+    value === 'null' ||
+    value === 'undefined'
+  );
+}


### PR DESCRIPTION
### 🔗 Linked Issue

-  #104  

### 🛠 개발 기능

- 콘솔 제거
- 서비스워커 인증 로직 변경
- indexedDB 사용 코드 제거
- 토큰 재발급 훅 구현

### 🧩 문제 원인
- 모달에서 토큰 재발급 코드 호출시 404 페이지로 이동하는 문제는 클라이언트 파일에서 서버 코드를 호출하려고 하여 발생한 문제였습니다.

### 🧩 해결 방법

- 에러 핸들링 파일은 클라이언트이므로, 토큰 재발급 코드를 훅을 통해 실행되도록 하여 서버 호출로 인한 문제를 해결하였습니다.
- 만약 클라이언트 파일에서 reissue를 호출하고자 한다면, `useUpdateSession`의 `callReissueFn` 함수를 사용하세요.

### 🔍 리뷰 포인트

- 

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
