### PR TITLE
서비스워커 캐싱 적용 및 오프라인 API 응답 반환

### DIFF
--- a/public/custom-sw.js
+++ b/public/custom-sw.js
@@ -13,9 +13,17 @@ const AUTH_MESSAGE = [
   UNSUPPORTED_JWT,
 ];
 
+const CACHE_NAME = 'athens-cache-static-v1';
+const DYNAMIC_CACHE_NAME = 'athens-cache-dynamic-v1';
+const CACHED_URLS = ['/', '/manifest.json'];
+
 let newAccessToken = '';
 const voteType = {
   type: 'DEFAULT',
+};
+
+const isNull = (value) => {
+  return value === null || value === undefined || value === '';
 };
 
 const tokenErrorHandler = async (baseUrl) => {
@@ -45,7 +53,7 @@ const call = async (baseUrl, url, fetchNext, retry = 3) => {
     try {
       const res = await response.json();
       // 인증 자격에 관한 오류 처리
-      if (res.error !== null && AUTH_MESSAGE.includes(response.error.message)) {
+      if (!isNull(res.error) && AUTH_MESSAGE.includes(response.error.message)) {
         await tokenErrorHandler(baseUrl);
         // 재발급 후 재요청
         if (retry !== 0) {
@@ -75,12 +83,116 @@ const call = async (baseUrl, url, fetchNext, retry = 3) => {
   return result;
 };
 
-this.addEventListener('install', () => {
-  this.skipWaiting();
+this.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(CACHED_URLS);
+    }),
+  );
+  // this.skipWaiting();
+});
+
+this.addEventListener('fetch', async (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => {
+      const requestUrl = new URL(event.request.url);
+
+      // chrome-extension 스킴을 가진 요청 제외
+      if (requestUrl.protocol === 'chrome-extension:') {
+        return fetch(event.request, { redirect: 'follow' });
+      }
+
+      // 네트워크 POST, PATCH 요청은 캐싱하지 않음
+      if (['POST', 'PATCH'].includes(event.request.method)) {
+        return fetch(event.request, { redirect: 'follow' }).catch(() => {
+          return new Response('', {
+            status: 200,
+            redirect: 'follow',
+          });
+        });
+      }
+
+      // 로그인 요청은 캐싱하지 않음
+      if (requestUrl.pathname.startsWith('/login')) {
+        return fetch(event.request).catch(() => {
+          return new Response('', {
+            status: 200,
+            redirect: 'follow',
+          });
+        });
+      }
+
+      // 그외 API 요청은 오프라인 상태에서의 캐싱 응답을 위해 캐싱한 후 네트워크 응답 반환
+      if (requestUrl.pathname.startsWith('/api/')) {
+        return fetch(event.request, { redirect: 'follow' })
+          .then(async (res) => {
+            const cache = await caches.open(DYNAMIC_CACHE_NAME);
+            // 캐시에 이미 같은 URL이 있다면 삭제 후 새로운 응답 캐싱 (캐시 업데이트)
+            const cachedResponse = await cache.match(event.request.url);
+            if (cachedResponse) {
+              await cache.delete(event.request.url);
+            }
+            await cache.put(event.request.url, res.clone());
+            return res;
+          })
+          .catch(() => {
+            // 네트워크 요청 실패 시 캐싱된 응답 반환
+            if (response) {
+              return response;
+            }
+            // 캐싱된 응답이 없다면 빈 응답 반환
+            return new Response('', {
+              status: 200,
+              redirect: 'follow',
+            });
+          });
+      }
+
+      // 리디렉션 응답 처리
+      if (response && response.redirected) {
+        return fetch(response.url, { redirect: 'follow' });
+      }
+
+      // 캐싱이 되어 있다면 캐싱된 응답을 반환
+      if (!isNull(response)) {
+        return response;
+      }
+
+      // 캐싱이 되어 있지 않다면 네트워크에서 가져온 응답을 반환
+      return fetch(event.request)
+        .then(async (res) => {
+          const cache = await caches.open(DYNAMIC_CACHE_NAME);
+          cache.put(event.request.url, res.clone());
+          return res;
+        })
+        .catch(() => {
+          return new Response('', {
+            status: 200,
+            redirect: 'follow',
+          });
+        });
+    }),
+  );
 });
 
 this.addEventListener('activate', (event) => {
-  event.waitUntil(this.clients.claim());
+  event.waitUntil(
+    // 현재 캐시된 캐시 이름을 제외한 다른 캐시들을 삭제 (최신 캐시로 업데이트)
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames.map((cacheName) => {
+          if (
+            cacheName !== CACHE_NAME &&
+            cacheName.startsWith('athens-cache')
+          ) {
+            return caches.delete(cacheName);
+          }
+          return null;
+        }),
+      );
+    }),
+    this.clients.claim(),
+  );
 });
 
 this.addEventListener('message', async (event) => {

--- a/src/app/(chat)/_lib/getAgoraUsers.ts
+++ b/src/app/(chat)/_lib/getAgoraUsers.ts
@@ -6,7 +6,10 @@ import { getAgoraUserListQueryKey as getAgoraUserListTags } from '@/constants/qu
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
-import { AGORA_USER } from '@/constants/responseErrorMessage';
+import {
+  AGORA_USER,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import isNull from '@/utils/validation/validateIsNull';
 
 export const getAgoraUsers: QueryFunction<
@@ -40,6 +43,8 @@ export const getAgoraUsers: QueryFunction<
       throw new Error(AGORA_USER.NOT_FOUND_AGORA);
     } else if (res.error.code === -1) {
       throw new Error(res.error.message);
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     throw new Error(AGORA_USER.FAILED_TO_GET_AGORA_USER);

--- a/src/app/(chat)/_lib/getChatMessages.ts
+++ b/src/app/(chat)/_lib/getChatMessages.ts
@@ -4,7 +4,10 @@ import { getChatMessagesQueryKey as getChatMessagesTags } from '@/constants/quer
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
-import { CHAT_MESSAGE } from '@/constants/responseErrorMessage';
+import {
+  CHAT_MESSAGE,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import isNull from '@/utils/validation/validateIsNull';
 
 type Meta = {
@@ -61,6 +64,8 @@ export const getChatMessages: QueryFunction<
       throw new Error(CHAT_MESSAGE.NOT_FOUND_AGORA);
     } else if (res.error.code === -1) {
       throw new Error(res.error.message);
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     throw new Error(CHAT_MESSAGE.FAILED_TO_GET_CHAT);

--- a/src/app/(chat)/_lib/getVoteResult.ts
+++ b/src/app/(chat)/_lib/getVoteResult.ts
@@ -5,7 +5,10 @@ import { getVoteResultQueryKey as getVoteResultTags } from '@/constants/queryKey
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
-import { VOTE_RESULT } from '@/constants/responseErrorMessage';
+import {
+  NETWORK_ERROR_MESSAGE,
+  VOTE_RESULT,
+} from '@/constants/responseErrorMessage';
 import isNull from '@/utils/validation/validateIsNull';
 
 type VoteResult = {
@@ -44,6 +47,8 @@ export const getVoteResult: QueryFunction<
 
     if (res.error.code === 1301) {
       throw new Error(VOTE_RESULT.NOT_FOUND_AGORA);
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     return {

--- a/src/app/(chat)/_lib/patchAgoraEnd.ts
+++ b/src/app/(chat)/_lib/patchAgoraEnd.ts
@@ -1,5 +1,8 @@
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
-import { AGORA_END } from '@/constants/responseErrorMessage';
+import {
+  AGORA_END,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import isNull from '@/utils/validation/validateIsNull';
@@ -40,6 +43,8 @@ export const patchAgoraEnd = async (agoraId: number) => {
       }
     } else if (res.error.code === 1102) {
       throw new Error(AGORA_END.OBSERVER_CANNOT_END);
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     throw new Error(AGORA_END.NOT_FOUND_AGORA_OR_USER);

--- a/src/app/(chat)/_lib/patchAgoraImg.ts
+++ b/src/app/(chat)/_lib/patchAgoraImg.ts
@@ -2,7 +2,10 @@ import { base64ToFile } from '@/utils/base64ToFile';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
-import { AGORA_IMAGE_UPDATE } from '@/constants/responseErrorMessage';
+import {
+  AGORA_IMAGE_UPDATE,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import isNull from '@/utils/validation/validateIsNull';
 
 type Props = {
@@ -42,6 +45,8 @@ export const patchAgoraImg = async ({ agoraId, fileUrl }: Props) => {
       throw new Error(AGORA_IMAGE_UPDATE.ONLY_HOST_CAN_UPDATE);
     } else if (res.error.code === 1301) {
       throw new Error(AGORA_IMAGE_UPDATE.NOT_FOUND_AGORA_OR_USER);
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     throw new Error(AGORA_IMAGE_UPDATE.FAILED_TO_UPDATE_IMAGE);

--- a/src/app/(chat)/_lib/patchAgoraStart.ts
+++ b/src/app/(chat)/_lib/patchAgoraStart.ts
@@ -1,5 +1,8 @@
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
-import { AGORA_START } from '@/constants/responseErrorMessage';
+import {
+  AGORA_START,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import isNull from '@/utils/validation/validateIsNull';
@@ -34,6 +37,8 @@ export const patchAgoraStart = async (agoraId: number) => {
       throw new Error(AGORA_START.NOT_FOUND_AGORA_OR_USER);
     } else if (res.error.code === 1102) {
       throw new Error(AGORA_START.OBSERVER_CANNOT_START);
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     throw new Error(AGORA_START.FAILED_TO_START_AGORA);

--- a/src/app/(chat)/_lib/patchAgoraTimeOut.ts
+++ b/src/app/(chat)/_lib/patchAgoraTimeOut.ts
@@ -1,5 +1,8 @@
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
-import { AGORA_TIME_OUT } from '@/constants/responseErrorMessage';
+import {
+  AGORA_TIME_OUT,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import isNull from '@/utils/validation/validateIsNull';
@@ -34,7 +37,10 @@ export const patchAgoraTimeOut = async (agoraId: number) => {
       throw new Error(AGORA_TIME_OUT.NOT_FOUND_AGORA);
     } else if (res.error.code === 1002) {
       throw new Error(AGORA_TIME_OUT.ALREADY_TIME_OUT);
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
+
     throw new Error(AGORA_TIME_OUT.FAILED_TO_TIME_OUT);
 
     // return null;

--- a/src/app/(chat)/_lib/patchChatExit.ts
+++ b/src/app/(chat)/_lib/patchChatExit.ts
@@ -1,5 +1,8 @@
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
-import { AGORA_EXIT } from '@/constants/responseErrorMessage';
+import {
+  AGORA_EXIT,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import isNull from '@/utils/validation/validateIsNull';
@@ -41,6 +44,8 @@ const patchChatExit = async ({ agoraId }: Props) => {
       ) {
         throw new Error(AGORA_EXIT.NOT_FOUND_USER);
       }
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     throw new Error(AGORA_EXIT.FAILED_TO_EXIT);

--- a/src/app/(chat)/_lib/postFilterBadWords.ts
+++ b/src/app/(chat)/_lib/postFilterBadWords.ts
@@ -1,5 +1,8 @@
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
-import { FILTER_BAD_WORDS } from '@/constants/responseErrorMessage';
+import {
+  FILTER_BAD_WORDS,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import isNull from '@/utils/validation/validateIsNull';
@@ -43,6 +46,8 @@ const postFilterBadWords = async ({ message, agoraId }: Props) => {
       ) {
         throw new Error(FILTER_BAD_WORDS.USER_NOT_PARTICIPATING);
       }
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     throw new Error(FILTER_BAD_WORDS.FAILED_TO_FILTER);

--- a/src/app/(main)/_lib/getAgoraCategorySearch.ts
+++ b/src/app/(main)/_lib/getAgoraCategorySearch.ts
@@ -1,5 +1,8 @@
 import { AgoraData } from '@/app/model/Agora';
-import { AGORA_CATEGORY_SEARCH } from '@/constants/responseErrorMessage';
+import {
+  AGORA_CATEGORY_SEARCH,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { QueryFunction } from '@tanstack/react-query';
 
@@ -50,6 +53,8 @@ export const getAgoraCategorySearch: QueryFunction<
       throw new Error(AGORA_CATEGORY_SEARCH.NOT_ALLOWED_CATEGORY);
     } else if (res.error.code === -1) {
       throw new Error(res.error.message);
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     throw new Error(AGORA_CATEGORY_SEARCH.FAILED_TO_GET_AGORA_LIST);

--- a/src/app/(main)/_lib/getAgoraKeywordSearch.ts
+++ b/src/app/(main)/_lib/getAgoraKeywordSearch.ts
@@ -1,5 +1,8 @@
 import { Agora } from '@/app/model/Agora';
-import { AGORA_KEYWORD_SEARCH } from '@/constants/responseErrorMessage';
+import {
+  AGORA_KEYWORD_SEARCH,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { QueryFunction } from '@tanstack/react-query';
 
@@ -44,9 +47,10 @@ export const getAgoraKeywordSearch: QueryFunction<
 
     if (res.error.code === 1001) {
       throw new Error(AGORA_KEYWORD_SEARCH.NOT_ALLOWED_STATUS);
-    }
-    if (res.error.code === -1) {
+    } else if (res.error.code === -1) {
       throw new Error(res.error.message);
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     throw new Error(AGORA_KEYWORD_SEARCH.FAILED_TO_GET_AGORA_LIST);

--- a/src/app/(main)/_lib/getAgoraTitle.ts
+++ b/src/app/(main)/_lib/getAgoraTitle.ts
@@ -3,7 +3,10 @@
 import { QueryFunction } from '@tanstack/react-query';
 import { getSelectedAgoraQueryKey as getSelectedAgoraTags } from '@/constants/queryKey';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
-import { AGORA_INFO } from '@/constants/responseErrorMessage';
+import {
+  AGORA_INFO,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 
 export const getAgoraTitle: QueryFunction<
   { title: string; status: string; imageUrl: string; agoraColor: string },
@@ -29,6 +32,8 @@ export const getAgoraTitle: QueryFunction<
 
     if (res.error.code === 1301) {
       throw new Error(AGORA_INFO.NOT_EXIST_AGORA);
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     throw new Error(AGORA_INFO.FAILED_TO_GET_AGORA_INFO);

--- a/src/app/(main)/_lib/getLivelyAgora.ts
+++ b/src/app/(main)/_lib/getLivelyAgora.ts
@@ -1,4 +1,7 @@
-import { AGORA_ACTIVE } from '@/constants/responseErrorMessage';
+import {
+  AGORA_ACTIVE,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 
 export const getLivelyAgora = async () => {
@@ -20,6 +23,8 @@ export const getLivelyAgora = async () => {
 
     if (res.error.code === 1002) {
       throw new Error(AGORA_ACTIVE.BAD_REQUEST);
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
   }
 

--- a/src/app/(main)/_lib/postCreateAgora.ts
+++ b/src/app/(main)/_lib/postCreateAgora.ts
@@ -3,7 +3,10 @@ import { base64ToFile } from '@/utils/base64ToFile';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import { AUTH_MESSAGE, SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
-import { AGORA_CREATE } from '@/constants/responseErrorMessage';
+import {
+  AGORA_CREATE,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import isNull from '@/utils/validation/validateIsNull';
 
 const TITLE_NULL = { title: '공백일 수 없습니다' };
@@ -84,6 +87,8 @@ export const postCreateAgora = async (info: AgoraConfig) => {
       ) {
         throw new Error(AGORA_CREATE.DURATION_OVER);
       }
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     } else if (AUTH_MESSAGE.includes(res.error.message)) {
       throw new Error(res.error.message);
     }

--- a/src/app/(main)/_lib/postEnterAgoraInfo.ts
+++ b/src/app/(main)/_lib/postEnterAgoraInfo.ts
@@ -3,7 +3,10 @@ import { AGORA_POSITION, AGORA_STATUS } from '@/constants/agora';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { SIGNIN_REQUIRED, TOKEN_EXPIRED } from '@/constants/authErrorMessage';
 import { getSession } from '@/serverActions/auth';
-import { AGORA_ENTER } from '@/constants/responseErrorMessage';
+import {
+  AGORA_ENTER,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
 import isNull from '@/utils/validation/validateIsNull';
 
 type Props = {
@@ -83,6 +86,8 @@ export const postEnterAgoraInfo = async ({ info, agoraId }: Props) => {
       }
     } else if (res.error.code === 2000) {
       throw new Error(AGORA_ENTER.FULL_CAPACITY);
+    } else if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     throw new Error(AGORA_ENTER.FAILED_TO_ENTER_AGORA);

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { getSession } from '@/serverActions/auth';
 import { redirect } from 'next/navigation';
+import isNull from '@/utils/validation/validateIsNull';
+import { homeSegmentKey } from '@/constants/segmentKey';
 import SignIn from './_components/templates/SignIn';
 
 export async function generateMetadata() {
@@ -26,8 +28,8 @@ export async function generateMetadata() {
 export default async function Page() {
   const session = await getSession();
 
-  if (session?.user) {
-    redirect('/home');
+  if (!isNull(session?.user)) {
+    redirect(homeSegmentKey);
     return null;
   }
 

--- a/src/app/(main)/user-info/_component/molecules/ActionButtons.tsx
+++ b/src/app/(main)/user-info/_component/molecules/ActionButtons.tsx
@@ -2,8 +2,6 @@
 
 import React from 'react';
 import { signOut, useSession } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
-import { homeSegmentKey } from '@/constants/segmentKey';
 import { AUTHENTICATED } from '@/constants/auth';
 import ActionButton from '../atoms/ActionButton';
 
@@ -13,12 +11,10 @@ type Props = {
 
 export function ActionButtons({ className }: Props) {
   const session = useSession();
-  const router = useRouter();
 
-  const handleSignOut = () => {
+  const handleSignOut = async () => {
     if (session?.status === AUTHENTICATED) {
-      signOut();
-      router.push(homeSegmentKey);
+      await signOut({ redirect: true });
     }
   };
 

--- a/src/app/(main)/user-info/_component/organisms/UserInfoMain.tsx
+++ b/src/app/(main)/user-info/_component/organisms/UserInfoMain.tsx
@@ -4,7 +4,7 @@ import Borderline from '../atoms/Borderline';
 import AccountInfos from '../molecules/AccountInfos';
 import { ActionButtons } from '../molecules/ActionButtons';
 
-export default function Main() {
+export default function UserInfoMain() {
   return (
     <main>
       <AccountInfos className="px-24 py-14" />

--- a/src/app/(main)/user-info/page.tsx
+++ b/src/app/(main)/user-info/page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Main from './_component/organisms/Main';
+import UserInfoMain from './_component/organisms/UserInfoMain';
 
 export default function Page() {
-  return <Main />;
+  return <UserInfoMain />;
 }

--- a/src/constants/responseErrorMessage.ts
+++ b/src/constants/responseErrorMessage.ts
@@ -142,3 +142,7 @@ export const REACTION_SOCKET_ERROR_MESSAGE = {
 export const CHAT_VOTE_ERROR_MESSAGE = {
   DUPLICATE_VOTE: 'User has already voted for Opinion in this agora',
 };
+
+export const NETWORK_ERROR_MESSAGE = {
+  OFFLINE: '인터넷 연결이 필요합니다. 다시 시도해주세요.',
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,7 @@ import isNull from './utils/validation/validateIsNull';
 export async function middleware() {
   const session = await getSession();
 
-  if (isNull(session)) {
+  if (isNull(session) || isNull(session?.user)) {
     return NextResponse.redirect(`${process.env.NEXT_CLIENT_URL}/`);
   }
 
@@ -14,5 +14,5 @@ export async function middleware() {
 }
 
 export const config = {
-  matcher: ['/agoras', '/flow/:path*', '/create-agora', '/user-info'],
+  matcher: ['/agoras/:path*', '/flow/:path*', '/create-agora', '/user-info'],
 };


### PR DESCRIPTION
### 🔗 Linked Issue

- [ ] #117 

resolved: 

### 🛠 개발 기능

- 서비스워커에서 제공하는 캐싱 기능을 사용하여 정적/동적 코드에 대해 캐싱 적용
- 오프라인시 캐싱된 데이터 사용
- 오프라인에서 API 요청시 인터넷 연결 확인 요청 응답 반환

### 🧩 해결 방법

- `user-info` 페이지의 `Main` 컴포넌트와 홈 화면의 `Main` 컴포넌트와 충돌이 발생해 로그아웃 후 홈 화면 컴포넌트가 출력되는 문제가 발생하였습니다.
  - `user-info` 페이지의 `Main` 컴포넌트의 이름을 `UserInfoMain`으로 변경하여 해결하였습니다.

- 페이지에 접속한 적이 있다면 서비스워커에 캐시합니다.
- 이전에 접속한 적이 있다면, 캐시한 데이터를 사용자에게 반환합니다. (UI, data)
  - API 요청의 경우 캐시 데이터가 아닌 실시간 데이터를 반환하고, 이를 항상 캐시하도록 합니다.
  - 캐시 용량 제어를 위해 같은 API 요청일 경우 해당 캐시를 갱신하도록 합니다.

### 🔍 리뷰 포인트

- 오프라인에서의 API 응답 코드는 `503`으로 지정했습니다.
- 이에 따른 메시지는 `'인터넷 연결이 필요합니다. 다시 시도해주세요.'`입니다.
- `responseErrorMessage.ts` 파일에 추가했으니 혹 사용하고자 한다면, import 하여 사용해주세요.

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
