### PR TITLE
가상스크롤 로직 변경 및 홈 버그 수정

### DIFF
--- a/src/app/(chat)/_components/atoms/ChatNotification.tsx
+++ b/src/app/(chat)/_components/atoms/ChatNotification.tsx
@@ -25,12 +25,7 @@ export default function ChatNotification() {
   return (
     !showMessage &&
     enterAgora.status !== AGORA_STATUS.CLOSED && (
-      <div
-        className="flex p-0.5rem pl-1rem pr-1rem"
-        style={{
-          transform: 'scaleY(-1)',
-        }}
-      >
+      <div className="flex p-0.5rem pl-1rem pr-1rem transform-scale-y-inverted">
         <div
           role="alert"
           aria-live="polite"

--- a/src/app/(chat)/_components/atoms/ChatNotification.tsx
+++ b/src/app/(chat)/_components/atoms/ChatNotification.tsx
@@ -25,7 +25,12 @@ export default function ChatNotification() {
   return (
     !showMessage &&
     enterAgora.status !== AGORA_STATUS.CLOSED && (
-      <div className="flex p-0.5rem pl-1rem pr-1rem">
+      <div
+        className="flex p-0.5rem pl-1rem pr-1rem"
+        style={{
+          transform: 'scaleY(-1)',
+        }}
+      >
         <div
           role="alert"
           aria-live="polite"

--- a/src/app/(chat)/_components/atoms/NotificationNewMessage.tsx
+++ b/src/app/(chat)/_components/atoms/NotificationNewMessage.tsx
@@ -2,6 +2,7 @@ import React, { KeyboardEventHandler, useEffect } from 'react';
 import UserImage from '@/app/_components/atoms/UserImage';
 import { Message } from '@/app/model/Message';
 import { PROFLELIST } from '@/constants/consts';
+import isNull from '@/utils/validation/validateIsNull';
 
 type Props = {
   message: Message;
@@ -19,7 +20,7 @@ export default function NotificationNewMessage({
   const clickMessage = () => {
     if (listRef.current) {
       setView(false);
-      listRef.current.scrollTo(0, listRef.current.scrollHeight);
+      listRef.current.scrollTo({ top: 0 });
     }
   };
 
@@ -35,11 +36,7 @@ export default function NotificationNewMessage({
     // 스크롤이 아래로 내려가면 새 메시지 알림을 숨김
     const handleScroll = () => {
       if (listRef.current) {
-        const scrollPosition =
-          listRef.current.scrollTop + listRef.current.clientHeight;
-        const { scrollHeight } = listRef.current;
-
-        if (scrollHeight - scrollPosition <= 100) {
+        if (listRef.current.scrollTop <= 100) {
           setView(false);
         }
       }
@@ -53,8 +50,10 @@ export default function NotificationNewMessage({
     };
   }, [view, listRef, setView]);
 
+  if (isNull(message)) return null;
+
   return (
-    <div className="w-full px-8 fixed bottom-55">
+    <div className="w-full px-8 absolute bottom-0">
       <button
         type="button"
         aria-label="새로운 메시지"

--- a/src/app/(chat)/_components/atoms/ScrollToBottomBtn.tsx
+++ b/src/app/(chat)/_components/atoms/ScrollToBottomBtn.tsx
@@ -13,7 +13,7 @@ export default function ScrollToBottomBtn({ listRef }: Props) {
   const handleScrollToBottom = () => {
     if (listRef.current) {
       setScrollToBottom(false);
-      listRef.current.scrollTo(0, listRef.current.scrollHeight);
+      listRef.current.scrollTo({ top: 0 });
     }
   };
 
@@ -31,11 +31,7 @@ export default function ScrollToBottomBtn({ listRef }: Props) {
     // 스크롤이 아래로 내려가면 새 메시지 알림을 숨김
     const handleScroll = () => {
       if (listRef.current) {
-        const scrollPosition =
-          listRef.current.scrollTop + listRef.current.clientHeight;
-        const { scrollHeight } = listRef.current;
-
-        if (scrollHeight - scrollPosition <= 200) {
+        if (listRef.current.scrollTop <= 200) {
           setScrollToBottom(false);
         } else {
           setScrollToBottom(true);

--- a/src/app/(chat)/_components/molecules/Message.tsx
+++ b/src/app/(chat)/_components/molecules/Message.tsx
@@ -191,7 +191,7 @@ export default function Message() {
   useEffect(() => {
     const [lastItem] = [...virtualItems].reverse();
 
-    if (!lastItem) {
+    if (isNull(lastItem)) {
       return;
     }
 
@@ -224,19 +224,19 @@ export default function Message() {
       e.preventDefault();
       const currentTarget = e.currentTarget as HTMLElement;
 
-      if (currentTarget) {
+      if (!isNull(currentTarget)) {
         currentTarget.scrollTop -= e.deltaY;
       }
     };
 
     const currentListRef = listRef.current;
-    if (currentListRef) {
+    if (!isNull(currentListRef)) {
       currentListRef.addEventListener('wheel', handleScroll, {
         passive: false,
       });
     }
     return () => {
-      if (currentListRef) {
+      if (!isNull(currentListRef)) {
         currentListRef.removeEventListener('wheel', handleScroll);
       }
     };
@@ -250,7 +250,7 @@ export default function Message() {
 
       // 새로 전달받은 메시지 업데이트 후에 스크롤 조정
       setTimeout(() => {
-        if (listRef.current) {
+        if (!isNull(listRef.current)) {
           // 입퇴장 속성이 있다면, 스크롤을 조정하지 않음
           if (lastMessage.access !== undefined) {
             setGoDown(false);
@@ -297,10 +297,7 @@ export default function Message() {
       <div
         key={agoraId}
         ref={listRef}
-        className="h-full w-full flex overflow-auto flex-col"
-        style={{
-          transform: 'scaleY(-1)',
-        }}
+        className="h-full w-full flex overflow-auto flex-col transform-scale-y-inverted"
       >
         <ChatNotification />
         <div

--- a/src/app/(chat)/_components/molecules/Message.tsx
+++ b/src/app/(chat)/_components/molecules/Message.tsx
@@ -100,7 +100,7 @@ function MessageItem({
 }
 
 export default function Message() {
-  const [newMessageView, setNewMessageView] = useState(true);
+  const [newMessageView, setNewMessageView] = useState(false);
   const adjustScrollRef = useRef(false);
   const listRef = useRef<HTMLDivElement>(null);
   const { shouldGoDown, setGoDown } = useMessageStore();

--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -158,7 +158,11 @@ export default function Header() {
   };
 
   const handleBack = async () => {
-    const result = await swalBackButtonAlert();
+    const text =
+      enterAgora.status === AGORA_STATUS.CLOSED
+        ? ''
+        : '설정한 프로필은 초기화됩니다.';
+    const result = await swalBackButtonAlert(text);
 
     if (result && result.isConfirmed) {
       handleAgoraExit();

--- a/src/app/(chat)/_lib/getChatMessages.ts
+++ b/src/app/(chat)/_lib/getChatMessages.ts
@@ -66,7 +66,7 @@ export const getChatMessages = (session: any) => {
     const result = res.response;
 
     return {
-      chats: result.chats.reverse(),
+      chats: result.chats,
       meta: result.meta,
     };
   };

--- a/src/app/(chat)/_lib/getChatMessagesServer.ts
+++ b/src/app/(chat)/_lib/getChatMessagesServer.ts
@@ -76,7 +76,7 @@ export const getChatMessagesServer: QueryFunction<
   const result = res.response;
 
   return {
-    chats: result.chats.reverse(),
+    chats: result.chats,
     meta: result.meta,
   };
 };

--- a/src/app/(chat)/agoras/[agora]/page.tsx
+++ b/src/app/(chat)/agoras/[agora]/page.tsx
@@ -51,7 +51,10 @@ export async function generateMetadata({ params }: Props) {
 export default function Page({ params }: Props) {
   const agoraId = Number(params.agora);
   return (
-    <main aria-label="채팅" className="flex flex-col justify-between h-full">
+    <main
+      aria-label="채팅"
+      className="relative flex flex-col justify-between h-full"
+    >
       <MessageContainer agoraId={agoraId} />
     </main>
   );

--- a/src/app/(main)/_components/atoms/AgoraStatusTab.tsx
+++ b/src/app/(main)/_components/atoms/AgoraStatusTab.tsx
@@ -2,7 +2,7 @@
 
 import { homeSegmentKey } from '@/constants/segmentKey';
 import { useSearchStore } from '@/store/search';
-import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -15,14 +15,14 @@ function AgoraStatusTab() {
       tabStatus: state.tabStatus,
     })),
   );
-  const searchParams = useSearchParams();
+  // const searchParams = useSearchParams();
   const [status, setStatus] = useState<Status>(tabStatus as Status);
   const router = useRouter();
   const pathname = usePathname();
 
   const changeParams = useCallback(() => {
     if (pathname !== homeSegmentKey) return;
-    const newSearchParams = new URLSearchParams(searchParams);
+    const newSearchParams = new URLSearchParams(window.location.search);
 
     newSearchParams.set('status', status);
     setTabStatus(status);
@@ -33,10 +33,7 @@ function AgoraStatusTab() {
       '',
       newUrl,
     );
-
-    // newSearchParams.set('status', status);
-    // router.push(`${homeSegmentKey}?${newSearchParams.toString()}`);
-  }, [router, searchParams, status, pathname]);
+  }, [router, status, pathname]);
 
   useEffect(() => {
     changeParams();

--- a/src/app/(main)/_components/atoms/CategoryAgoraNowTitle.tsx
+++ b/src/app/(main)/_components/atoms/CategoryAgoraNowTitle.tsx
@@ -1,6 +1,7 @@
 import RefreshIcon from '@/assets/icons/RefreshIcon';
+import { getCategoryAgoraListBasicQueryKey } from '@/constants/queryKey';
 import { useQueryClient } from '@tanstack/react-query';
-import React from 'react';
+import React, { useCallback } from 'react';
 
 type ActiveHeaderProps = {
   tabStatus: string;
@@ -9,19 +10,22 @@ type ActiveHeaderProps = {
 function CategoryAgoraNowTitle({ tabStatus }: ActiveHeaderProps) {
   const queryClient = useQueryClient();
 
-  const handleKeyDownRefresh = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      queryClient.refetchQueries({
-        queryKey: ['agoras', 'search', 'category'],
-      });
-    }
-  };
+  const handleKeyDownRefresh = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        queryClient.invalidateQueries({
+          queryKey: getCategoryAgoraListBasicQueryKey(),
+        });
+      }
+    },
+    [queryClient],
+  );
 
-  const handleClickRefresh = () => {
-    queryClient.refetchQueries({
-      queryKey: ['agoras', 'search', 'category'],
+  const handleClickRefresh = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: getCategoryAgoraListBasicQueryKey(),
     });
-  };
+  }, [queryClient]);
 
   return (
     tabStatus === 'active' && (

--- a/src/app/(main)/_components/organisms/CategoryButtonContainer.tsx
+++ b/src/app/(main)/_components/organisms/CategoryButtonContainer.tsx
@@ -3,17 +3,20 @@
 import React, { Suspense } from 'react';
 import { useSearchStore } from '@/store/search';
 import { useShallow } from 'zustand/react/shallow';
+import { usePathname } from 'next/navigation';
+import { createAgoraSegmentKey } from '@/constants/segmentKey';
 import CategoryButtonList from '../molecules/CategoryButtonList';
 import CategoryButtonListSkeleton from '../atoms/CategoryButtonListSkeleton';
 
 export default function CategoryButtonContainer() {
+  const pathname = usePathname();
   const { search } = useSearchStore(
     useShallow((state) => ({
       search: state.search,
     })),
   );
 
-  if (!search) {
+  if (!search || pathname === createAgoraSegmentKey) {
     return (
       <Suspense fallback={<CategoryButtonListSkeleton />}>
         <CategoryButtonList />

--- a/src/app/(main)/create-agora/_component/CreateAgoraBtn.tsx
+++ b/src/app/(main)/create-agora/_component/CreateAgoraBtn.tsx
@@ -6,7 +6,7 @@ import {
   useMutation,
   useQueryClient,
 } from '@tanstack/react-query';
-import React, { useEffect, useState } from 'react';
+import React, { KeyboardEventHandler, useEffect, useState } from 'react';
 import { useCreateAgora } from '@/store/create';
 import { useRouter } from 'next/navigation';
 import { useAgora } from '@/store/agora';
@@ -126,6 +126,12 @@ function CreateAgoraBtn() {
     mutation.mutate();
   };
 
+  const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = (e) => {
+    if (e.key === 'Enter') {
+      handleClick();
+    }
+  };
+
   useEffect(() => {
     return () => {
       const { reset: createStoreReset } = useCreateAgora.getState();
@@ -139,25 +145,24 @@ function CreateAgoraBtn() {
   }, []);
 
   return (
-    <div className="mt-1rem w-full">
-      <button
-        onClick={handleClick}
-        type="button"
-        disabled={isLoading}
-        aria-label="아고라 생성하기"
-        className="w-full bg-athens-main text-white font-semibold pt-10 pb-10 under-mobile:pt-10 under-mobile:pb-10 under-mobile:mt-1rem text-base rounded-lg"
-      >
-        {isLoading ? (
-          <Loading
-            w="16"
-            h="16"
-            className="m-2 flex justify-center items-center"
-          />
-        ) : (
-          '아고라 생성'
-        )}
-      </button>
-    </div>
+    <button
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      type="submit"
+      disabled={isLoading}
+      aria-label="아고라 생성하기"
+      className="mt-1rem w-full bg-athens-main text-white pt-6 pb-6 under-mobile:pt-6 under-mobile:pb-6 under-mobile:mt-1rem text-base rounded-lg"
+    >
+      {isLoading ? (
+        <Loading
+          w="19"
+          h="19"
+          className="m-2 flex justify-center items-center"
+        />
+      ) : (
+        '아고라 생성'
+      )}
+    </button>
   );
 }
 

--- a/src/app/(main)/login/auth/components/AuthLogin.tsx
+++ b/src/app/(main)/login/auth/components/AuthLogin.tsx
@@ -44,6 +44,9 @@ export default function AuthLogin({ user }: Props) {
   }, [router, session]);
 
   useLayoutEffect(() => {
+    if (isNull(user)) {
+      return;
+    }
     getUserAccessToken(user);
   }, [getUserAccessToken, user]);
 

--- a/src/app/(main)/login/auth/components/AuthLogin.tsx
+++ b/src/app/(main)/login/auth/components/AuthLogin.tsx
@@ -5,7 +5,7 @@ import showToast from '@/utils/showToast';
 import { signInWithCredentials } from '@/serverActions/auth';
 import { signIn, useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect } from 'react';
 import isNull from '@/utils/validation/validateIsNull';
 
 type Props = {
@@ -16,33 +16,36 @@ export default function AuthLogin({ user }: Props) {
   const router = useRouter();
   const { data: session } = useSession();
 
-  const getUserAccessToken = async (authuser: string) => {
-    const tempToken = await signInWithCredentials(authuser);
+  const getUserAccessToken = useCallback(
+    async (authuser: string) => {
+      const tempToken = await signInWithCredentials(authuser);
 
-    if (tempToken.success) {
-      try {
-        await signIn('credentials', {
-          accessToken: tempToken.accessToken,
-        });
-      } catch (error) {
+      if (tempToken.success) {
+        try {
+          await signIn('credentials', {
+            accessToken: tempToken.accessToken,
+          });
+        } catch (error) {
+          showToast('로그인에 실패했습니다. 다시 시도해주세요.', 'error');
+          router.replace('/');
+        }
+      } else if (!tempToken.success) {
         showToast('로그인에 실패했습니다. 다시 시도해주세요.', 'error');
         router.replace('/');
       }
-    } else if (!tempToken.success) {
-      showToast('로그인에 실패했습니다. 다시 시도해주세요.', 'error');
-      router.replace('/');
-    }
-  };
+    },
+    [router],
+  );
 
   useEffect(() => {
     if (!isNull(session)) {
       router.replace('/home');
     }
-  }, [session]);
+  }, [router, session]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     getUserAccessToken(user);
-  }, []);
+  }, [getUserAccessToken, user]);
 
   return (
     <div className="min-w-300 w-full h-full flex absolute justify-center items-center z-20 top-0 right-0 left-0 bottom-0 bg-opacity-50 bg-dark-bg-dark">

--- a/src/app/_components/organisms/AgoraImageUpload.tsx
+++ b/src/app/_components/organisms/AgoraImageUpload.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import React, {
   ChangeEventHandler,
   KeyboardEventHandler,
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -143,27 +144,31 @@ export default function AgoraImageUpload({ image = '', page, color }: Props) {
     }
   };
 
-  const renderMedia = (file: { dataUrl: string; file: File }) => {
-    if (file.file.type === 'image/gif') {
+  const renderMedia = useCallback(
+    (file: { dataUrl: string; file: File }) => {
+      if (file.file.type === 'image/gif') {
+        return (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={file.dataUrl}
+            alt="아고라 프로필"
+            className="object-cover h-full rounded-3xl under-mobile:rounded-2xl"
+          />
+        );
+      }
+
       return (
-        <img
+        <Image
+          alt="아고라 프로필"
+          layout="fill"
+          objectFit="cover"
+          className="rounded-3xl under-mobile:rounded-2xl"
           src={file.dataUrl}
-          alt="얍프로필"
-          className="object-cover h-full rounded-3xl under-mobile:rounded-2xl"
         />
       );
-    }
-
-    return (
-      <Image
-        alt="아고라 프로필"
-        layout="fill"
-        objectFit="cover"
-        className="rounded-3xl under-mobile:rounded-2xl"
-        src={file.dataUrl}
-      />
-    );
-  };
+    },
+    [uploadImage.dataUrl, cropedPreview.dataUrl],
+  );
 
   return (
     <div className="relative">

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -26,6 +26,12 @@ const getCategoryAgoraListQueryKey = (
   { ...searchParams, category: selectedCategory },
 ];
 
+const getCategoryAgoraListBasicQueryKey = () => [
+  'agoras',
+  'search',
+  'category',
+];
+
 const getKeywordAgoraListQueryKey = (
   searchParams: SearchParams,
   search?: string,
@@ -51,6 +57,7 @@ export {
   getChatMessagesQueryKey,
   getAgoraUserListQueryKey,
   getCategoryAgoraListQueryKey,
+  getCategoryAgoraListBasicQueryKey,
   getKeywordAgoraListQueryKey,
   getSelectedAgoraQueryKey,
   getUserReactionQueryKey,

--- a/src/utils/swalAlert.ts
+++ b/src/utils/swalAlert.ts
@@ -27,11 +27,11 @@ const swalConfirmAlertCustomClass = Swal.mixin({
   },
 });
 
-export const swalBackButtonAlert = async () => {
+export const swalBackButtonAlert = async (text: string) => {
   return swalConfirmCancelCustomClass.fire({
     icon: 'warning',
     title: '아고라를 나가시겠습니까?',
-    text: '설정한 프로필은 초기화됩니다.',
+    text,
     showCancelButton: true,
     confirmButtonText: '확인',
     cancelButtonText: '취소',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -134,6 +134,9 @@ const config: Config = {
           },
           appearance: 'textfield',
         },
+        '.transform-scale-y-inverted': {
+          transform: 'scaleY(-1)',
+        },
       });
     },
   ],


### PR DESCRIPTION
### 🔗 Linked Issue

### 🛠 개발 기능

- `useInView`를 사용하던 가상스크롤 로직을 제거하고 wheel 이벤트를 사용하여 새로운 데이터를 불러오도록 수정
- 홈의 URL searchParams가 탭 변경시 이전 데이터로 출력되는 버그 수정

### 🧩 해결 방법

- 가상스크롤은 채팅 리스트 컴포넌트를 scaleY(-1)로 뒤집은 뒤(스크롤), 메시지 컴포넌트를 다시 scaleY(-1)로 돌려줘 마우스 휠 로직이 반대로 동작하도록 했습니다.
- 이에 wheel 이벤트를 추가하여 기존 마우스 동작대로 스크롤을 움직여도 정상 작동하도록 하였습니다.

### 🔍 리뷰 포인트

- 

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
