### PR TITLE
종료된 아고라에 유저 인증 로직 추가

### DIFF
--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -70,8 +70,11 @@ export default function Header() {
   const { toggle } = useSidebarStore(
     useShallow((state) => ({ toggle: state.toggle })),
   );
-  const { enterAgora } = useAgora(
-    useShallow((state) => ({ enterAgora: state.enterAgora })),
+  const { enterAgora, reset: selectedAgoraReset } = useAgora(
+    useShallow((state) => ({
+      enterAgora: state.enterAgora,
+      reset: state.reset,
+    })),
   );
   const {
     setTitle,
@@ -161,6 +164,7 @@ export default function Header() {
 
   const handleAgoraExit = () => {
     if (enterAgora.status === AGORA_STATUS.CLOSED) {
+      selectedAgoraReset();
       router.push(homeSegmentKey);
     } else if (
       enterAgora.status === AGORA_STATUS.RUNNING ||

--- a/src/app/(main)/_components/atoms/NoAgoraMessage.tsx
+++ b/src/app/(main)/_components/atoms/NoAgoraMessage.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 export default function NoAgoraMessage() {
   return (
     <div className="flex flex-col items-center justify-start pt-12 pb-32">
-      <p className="text-gray-500 dark:text-dark-line-light text-sm">
+      <p
+        aria-label="출력된 텍스트"
+        className="text-gray-500 dark:text-dark-line-light text-sm"
+      >
         아직 등록된 아고라가 없습니다.
       </p>
     </div>

--- a/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
@@ -141,8 +141,8 @@ export default function CategoryAgoraList({ searchParams }: Props) {
       {(isFetching || isPending || isFetchingNextPage) && (
         <DeferredComponent>
           <Loading
-            w="32"
-            h="32"
+            w="25"
+            h="25"
             className="m-5 flex justify-center items-center"
           />
         </DeferredComponent>

--- a/src/app/(main)/_components/molecules/LivelyAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/LivelyAgoraList.tsx
@@ -112,8 +112,8 @@ export default function LivelyAgoraList() {
         <div className="min-h-64 w-full">
           <DeferredComponent>
             <Loading
-              w="26"
-              h="26"
+              w="25"
+              h="25"
               className="m-5 flex justify-center items-center"
             />
           </DeferredComponent>

--- a/src/app/(main)/_components/templates/Main.tsx
+++ b/src/app/(main)/_components/templates/Main.tsx
@@ -13,11 +13,11 @@ const AgoraListDeciderHydration = dynamic(
 
 export default function Main({ searchParams }: Props) {
   return (
-    <main className="justify-center items-stretch flex flex-col h-dvh flex-1 relative">
-      <section
-        aria-label="아고라 리스트"
-        className="flex h-full flex-col p-5 pt-3 pb-5rem justify-start items-center"
-      >
+    <main
+      aria-label="아고라 리스트"
+      className="justify-center items-stretch flex flex-col h-dvh flex-1 relative"
+    >
+      <div className="flex h-full flex-col p-5 pt-3 pb-5rem justify-start items-center">
         <Suspense
           fallback={
             <Loading className="m-5 flex justify-center items-center" />
@@ -25,7 +25,7 @@ export default function Main({ searchParams }: Props) {
         >
           <AgoraListDeciderHydration searchParams={searchParams} />
         </Suspense>
-      </section>
+      </div>
     </main>
   );
 }

--- a/src/app/(main)/_components/templates/SignIn.tsx
+++ b/src/app/(main)/_components/templates/SignIn.tsx
@@ -2,32 +2,53 @@ import React from 'react';
 import SNSLogin from '@/app/_components/molecules/SNSLogin';
 import Athens from '@/assets/icons/Athens';
 import Image from 'next/image';
+import BackIcon from '@/assets/icons/BackIcon';
+import Link from 'next/link';
 
 export default function SignIn() {
   return (
-    <main className="mx-auto tablet:w-[768px] min-h-screen w-full p-50 flex flex-col justify-around items-center">
+    <main
+      aria-label="로그인 페이지"
+      className="mx-auto tablet:w-[768px] min-h-screen w-full p-50 flex flex-col justify-around items-center"
+    >
       <div className="flex w-full h-full justify-center items-center relative">
         <div className="justify-center items-center w-full h-full flex">
           <h1
             aria-label="Athens"
             className="pt-20 flex justify-center items-center gap-x-12"
           >
-            <Image src="/athens.png" alt="Athens 로고" width={50} height={50} />
+            <Image
+              aria-hidden
+              src="/athens.png"
+              alt="Athens 로고"
+              width={50}
+              height={50}
+            />
           </h1>
           <div className="relative w-full flex-1 flex flex-col ml-12 justify-start">
             <Athens className="w-85 h-85" />
-            <p className="absolute w-full top-60 text-xs tablet:text-sm break-keep dark:text-white">
+            <p
+              aria-label="Athens 추가설명"
+              className="absolute w-full top-60 text-xs tablet:text-sm break-keep dark:text-white"
+            >
               익명으로 연결된 순간, 다양한 의견을 자유롭게 나누세요.
             </p>
           </div>
         </div>
       </div>
-      <div className="w-full flex flex-col gap-y-12 justify-center items-center">
-        <div className="text-sm dark:text-dark-line text-dark-light-500 p-10 pb-20">
-          SNS 계정으로 로그인
+      <section className="w-full flex flex-col justify-center items-center text-sm dark:text-dark-line text-dark-light-500">
+        <div className="flex flex-col gap-y-12 w-full justify-center items-center p-10 pb-20">
+          <h2 className="mb-12">SNS 계정으로 로그인</h2>
+          <SNSLogin />
         </div>
-        <SNSLogin />
-      </div>
+        <Link
+          href="/home"
+          className="text-sm dark:text-white text-black flex mt-24"
+        >
+          비회원으로 둘러보기
+          <BackIcon className="w-12 transform rotate-180" />
+        </Link>
+      </section>
     </main>
   );
 }

--- a/src/app/(main)/_lib/getEnterClosedAgoraStatus.ts
+++ b/src/app/(main)/_lib/getEnterClosedAgoraStatus.ts
@@ -1,0 +1,46 @@
+import { callFetchWrapper } from '@/lib/fetchWrapper';
+import { AUTH_MESSAGE, SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
+import { getSession } from '@/serverActions/auth';
+import {
+  AGORA_ENTER,
+  NETWORK_ERROR_MESSAGE,
+} from '@/constants/responseErrorMessage';
+import isNull from '@/utils/validation/validateIsNull';
+
+export const getEnterClosedAgoraStatus = async (agoraId: number) => {
+  const session = await getSession();
+  if (isNull(session)) {
+    throw new Error(SIGNIN_REQUIRED);
+  }
+
+  const res = await callFetchWrapper(`/api/v1/auth/${agoraId}/participate`, {
+    method: 'get',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${session.user?.accessToken}`,
+    },
+    credentials: 'include',
+  });
+
+  if (!res.ok && !res.success) {
+    if (!res.error) {
+      throw new Error(AGORA_ENTER.UNKNOWN_ERROR);
+    }
+
+    if (AUTH_MESSAGE.includes(res.error.message)) {
+      throw new Error(res.error.message);
+    }
+    if (res.error.code === 1002) {
+      throw new Error(AGORA_ENTER.ACTIVATE_AGORA);
+    }
+    if (res.error.code === 503) {
+      throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
+    }
+
+    throw new Error(AGORA_ENTER.FAILED_TO_ENTER_AGORA);
+  }
+
+  const result = res.response;
+
+  return result;
+};

--- a/src/app/(main)/_lib/getEnterClosedAgoraStatus.ts
+++ b/src/app/(main)/_lib/getEnterClosedAgoraStatus.ts
@@ -13,14 +13,17 @@ export const getEnterClosedAgoraStatus = async (agoraId: number) => {
     throw new Error(SIGNIN_REQUIRED);
   }
 
-  const res = await callFetchWrapper(`/api/v1/auth/${agoraId}/participate`, {
-    method: 'get',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${session.user?.accessToken}`,
+  const res = await callFetchWrapper(
+    `/api/v1/auth/agoras/${agoraId}/participants`,
+    {
+      method: 'get',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.user?.accessToken}`,
+      },
+      credentials: 'include',
     },
-    credentials: 'include',
-  });
+  );
 
   if (!res.ok && !res.success) {
     if (!res.error) {

--- a/src/app/(main)/_lib/postEnterAgoraInfo.ts
+++ b/src/app/(main)/_lib/postEnterAgoraInfo.ts
@@ -54,6 +54,10 @@ export const postEnterAgoraInfo = async ({ info, agoraId }: Props) => {
       throw new Error(AGORA_ENTER.UNKNOWN_ERROR);
     }
 
+    if (AUTH_MESSAGE.includes(res.error.message)) {
+      throw new Error(res.error.message);
+    }
+
     if (res.error.code === 1001) {
       if (info.id === null) {
         throw new Error(AGORA_ENTER.PROFILE_NULL);

--- a/src/app/_components/atoms/loading.tsx
+++ b/src/app/_components/atoms/loading.tsx
@@ -10,7 +10,7 @@ export default function Loading({ w = '30', h = '30', className = '' }: Props) {
   const size = `w-${w} h-${h}`;
 
   return (
-    <div role="status" className={className}>
+    <div role="status" aria-label="로딩중" className={className}>
       <svg
         aria-hidden="true"
         className={`${size} max-w-30 max-h-30 text-gray-200 animate-spin dark:text-gray-600 fill-athens-main`}

--- a/src/app/_components/molecules/SNSLogin.tsx
+++ b/src/app/_components/molecules/SNSLogin.tsx
@@ -11,7 +11,7 @@ export default function SNSLogin() {
       <Link
         href={getRedirectUri('kakao')}
         aria-label="카카오로 로그인하기"
-        className="text-sm relative flex justify-center items-center w-full bg-[#FEE500] border-1 border-[#FEE500] rounded-md h-42 p-12"
+        className="text-sm text-black relative flex justify-center items-center w-full bg-[#FEE500] border-1 border-[#FEE500] rounded-md h-42 p-12"
       >
         <div className="absolute left-12" aria-hidden>
           <svg
@@ -26,14 +26,17 @@ export default function SNSLogin() {
             />
           </svg>
         </div>
-        <div className="opacity-85 flex-1 justify-center items-center text-center">
+        <div
+          aria-hidden
+          className="opacity-85 flex-1 justify-center items-center text-center"
+        >
           카카오 로그인
         </div>
       </Link>
       <Link
         href={getRedirectUri('google')}
         aria-label="구글로 로그인하기"
-        className="text-sm relative flex justify-center items-center w-full bg-white border-1 border-dark-line-semilight rounded-md h-42 p-12"
+        className="text-sm text-black relative flex justify-center items-center w-full bg-white border-1 border-dark-line-semilight rounded-md h-42 p-12"
       >
         <div className="absolute left-12" aria-hidden>
           <svg
@@ -60,7 +63,10 @@ export default function SNSLogin() {
             />
           </svg>
         </div>
-        <div className="opacity-85 flex-1 justify-center items-center text-center">
+        <div
+          aria-hidden
+          className="opacity-85 flex-1 justify-center items-center text-center"
+        >
           구글 로그인
         </div>
       </Link>

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -123,7 +123,7 @@ export const authConfig: NextAuthConfig = {
     },
     redirect: async ({ url, baseUrl }) => {
       if (url) {
-        const { search, origin, pathname } = new URL(url);
+        const { search, pathname } = new URL(url);
         const callbackUrl = new URLSearchParams(search).get('callbackUrl');
 
         if (!isNull(callbackUrl)) {
@@ -137,7 +137,7 @@ export const authConfig: NextAuthConfig = {
           return `${baseUrl}/home`;
         }
 
-        if (origin === baseUrl) return url;
+        // if (origin === baseUrl) return url;
       }
 
       return baseUrl;

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -3,7 +3,7 @@ import { SearchParams } from '@/app/model/Agora';
 const getVoteResultQueryKey = (agoraId: number): [string, string, string] => [
   'agora',
   `${agoraId}`,
-  'closed',
+  'voteResult',
 ];
 
 const getChatMessagesQueryKey = (agoraId: number): [string, string, string] => [
@@ -32,6 +32,12 @@ const getCategoryAgoraListBasicQueryKey = () => [
   'category',
 ];
 
+const getClosedAgoraQueryKey = (agoraId: number): [string, string, string] => [
+  'agora',
+  `${agoraId}`,
+  'closed',
+];
+
 const getKeywordAgoraListQueryKey = (
   searchParams: SearchParams,
   search?: string,
@@ -58,6 +64,7 @@ export {
   getAgoraUserListQueryKey,
   getCategoryAgoraListQueryKey,
   getCategoryAgoraListBasicQueryKey,
+  getClosedAgoraQueryKey,
   getKeywordAgoraListQueryKey,
   getSelectedAgoraQueryKey,
   getUserReactionQueryKey,

--- a/src/constants/responseErrorMessage.ts
+++ b/src/constants/responseErrorMessage.ts
@@ -36,6 +36,7 @@ export const AGORA_CREATE = {
 export const AGORA_ENTER = {
   FAILED_TO_ENTER_AGORA: '입장 실패했습니다.\n 다시 시도해주세요.',
   CLOSED_AGORA: '종료된 아고라입니다.',
+  ACTIVATE_AGORA: '종료되지 않은 아고라입니다.',
   ALREADY_PARTICIPATED: '이미 참여한 아고라입니다.',
   NICKNAME_DUPLICATED: '닉네임이 중복됩니다.',
   NOT_ALLOWED_POSITION: '허용되지 않는 입장 타입 입니다.',


### PR DESCRIPTION
### 🔗 Linked Issue

### 🛠 개발 기능

- 로그인 페이지에 비회원으로 불러오기 Link 추가
- 종료된 아고라 접근시 인증 로직 실행

### 🧩 해결 방법

- 

### 🔍 리뷰 포인트

- 홈에서 인기 아고라, 활성화 아고라 로더의 크기가 달라서 통일시켜주었습니다.

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
