### PR TITLE
카테고리별 새로고침 작동 안되는 문제 수정

### DIFF
--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -141,6 +141,10 @@ export default function Header() {
     await queryClient.invalidateQueries({
       queryKey: getAgoraUserListQueryKey(agoraId),
     });
+
+    await queryClient.refetchQueries({
+      queryKey: getAgoraUserListQueryKey(agoraId),
+    });
   };
 
   const callChatExitAPI = async () => {

--- a/src/app/(main)/_components/molecules/AgoraListDecider.tsx
+++ b/src/app/(main)/_components/molecules/AgoraListDecider.tsx
@@ -94,7 +94,7 @@ export default function AgoraListDecider({ searchParams }: Props) {
         </>
       )}
       <ErrorBoundary FallbackComponent={FallbackComponent}>
-        <CategoryAgoraNowTitle tabStatus={tabStatus} />
+        <CategoryAgoraNowTitle searchParams={searchParams} />
         <CategoryAgoraList searchParams={searchParams} />
       </ErrorBoundary>
     </>

--- a/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
@@ -94,18 +94,22 @@ export default function CategoryAgoraList({ searchParams }: Props) {
   );
 
   useEffect(() => {
+    const refetchAgoraList = async () => {
+      await queryClient.resetQueries({
+        queryKey: getCategoryAgoraListBasicQueryKey(),
+      });
+
+      await queryClient.invalidateQueries({
+        queryKey: [
+          'agoras',
+          'search',
+          'category',
+          { ...searchParams, status: tabStatus, category: selectedCategory },
+        ],
+      });
+    };
     // 초기 데이터 호출 후 카테고리 변경 시 데이터 재호출
-    queryClient.resetQueries({
-      queryKey: getCategoryAgoraListBasicQueryKey(),
-    });
-    queryClient.invalidateQueries({
-      queryKey: [
-        'agoras',
-        'search',
-        'category',
-        { ...searchParams, status: tabStatus, category: selectedCategory },
-      ],
-    });
+    refetchAgoraList();
   }, [selectedCategory, queryClient, tabStatus, searchParams, refetch]);
 
   useEffect(() => {

--- a/src/app/(main)/create-agora/_component/CreateAgoraBtn.tsx
+++ b/src/app/(main)/create-agora/_component/CreateAgoraBtn.tsx
@@ -47,8 +47,8 @@ function CreateAgoraBtn() {
     })),
   );
 
-  const invalidAgora = (client: QueryClient, queryKey: string[]) => {
-    client.invalidateQueries({ queryKey });
+  const invalidAgora = async (client: QueryClient, queryKey: string[]) => {
+    await client.invalidateQueries({ queryKey });
   };
 
   const failedCreateAgora = async (
@@ -82,7 +82,7 @@ function CreateAgoraBtn() {
 
         setIsLoading(false);
 
-        invalidAgora(queryClient, ['agora']);
+        await invalidAgora(queryClient, ['agora']);
         router.push(`/flow${enterAgoraSegmentKey}/${response.id}`);
         return;
       }


### PR DESCRIPTION
### 🔗 Linked Issue

### 🛠 개발 기능

- '전체' 카테고리가 아닌 그 외 카테고리에서의 새로고침 버튼이 동작하지 않는 문제 수정

### 🧩 해결 방법

- 전역 상태로 관리하던 category, tabStatus를 불러와 query에 적용

### 🔍 리뷰 포인트

- 

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
