### PR TITLE
채팅방 새로고침 시 프로필 유지하도록 개선

### DIFF
--- a/src/app/(chat)/_components/atoms/ChatPageLoading.tsx
+++ b/src/app/(chat)/_components/atoms/ChatPageLoading.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import React from 'react';
+import BackButton from '@/app/_components/atoms/BackButton';
+import Loading from '@/app/_components/atoms/loading';
+import HamburgerIcon from '@/assets/icons/HamburgerIcon';
+import SendIcon from '@/assets/icons/SendIcon';
+import ShareButton from '../molecules/ShareButton';
+import DiscussionStatus from '../molecules/DiscussionStatus';
+import AgoraInfo from '../molecules/AgoraInfo';
+
+export default function () {
+  return (
+    <div className="h-dvh w-full relative">
+      <div className="min-w-300 w-full h-dvh flex absolute justify-center items-center z-10 top-0 right-0 left-0 bottom-0 bg-opacity-50 bg-dark-bg-dark">
+        <Loading className="absolute z-20" w="32" h="32" />
+      </div>
+      <div className="w-full overflow-y-hidden overflow-x-hidden h-dvh flex justify-center items-center xl:w-[1580px] relative">
+        <section className="w-full flex flex-1 h-dvh max-lg:pb-3rem min-w-270 flex-grow max-width-screen absolute top-0">
+          <section className="flex flex-1 flex-col w-full relative h-dvh">
+            <section className="sticky w-full top-0 bg-white dark:bg-dark-bg-light pt-10 min-w-270 border-b-1 border-gray-200 dark:border-dark-light-300">
+              <div className="flex flex-col w-full h-full justify-center dark:text-white dark:text-opacity-85">
+                <div className="flex justify-between items-center pb-10 border-b-1 border-gray-200 dark:border-dark-bg-light">
+                  <BackButton />
+                  <div className="flex justify-center items-center text-xs">
+                    <DiscussionStatus meta={undefined} />
+                  </div>
+                  <div className="flex justify-end items-center mr-0.5rem">
+                    <ShareButton title="" />
+                    <HamburgerIcon className="w-20 lg:w-22 cursor-pointer" />
+                  </div>
+                </div>
+                <div className="flex justify-center items-center">
+                  <AgoraInfo
+                    title="[ 채팅방을 세팅하는 중입니다... ]"
+                    pros={0}
+                    cons={0}
+                  />
+                </div>
+              </div>
+            </section>
+            <div className="h-full w-full flex overflow-auto flex-col transform-scale-y-inverted">
+              <div className="relative w-full flex flex-col" />
+            </div>
+            <section className="flex border-t-1 dark:border-dark-light-300 sticky bottom-0 right-0 left-0 w-full bg-white dark:bg-dark-light-300">
+              <form className="pl-1rem p-10 pb-0 flex flex-1 justify-start items-center">
+                <div
+                  role="textbox"
+                  tabIndex={0}
+                  aria-label="보낼 메세지 입력창"
+                  contentEditable
+                  data-placeholder="메시지 보내기"
+                  className="placeholder:text-athens-gray-thick dark:placeholder:text-dark-light-400
+            dark:placeholder:text-opacity-85 dark:text-opacity-85 dark:text-white w-full text-sm lg:text-base
+            focus-visible:outline-none dark:bg-dark-light-300 resize-none overflow-hidden h-35"
+                />
+              </form>
+              <div
+                aria-label="메세지 보내기"
+                className="bg-athens-main pl-10 pr-10 cursor-pointer h-full"
+              >
+                <SendIcon className="w-30" fill="white" />
+              </div>
+            </section>
+          </section>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(chat)/_components/molecules/Message.tsx
+++ b/src/app/(chat)/_components/molecules/Message.tsx
@@ -136,7 +136,14 @@ export default function Message() {
     { meta: Meta }
   >({
     queryKey: getChatMessagesQueryKey(agoraId),
-    queryFn: getChatMessages(session),
+    queryFn: isNull(session)
+      ? async () => {
+          return {
+            chats: [],
+            meta: { key: null, effectiveSize: 20 },
+          };
+        }
+      : getChatMessages(session),
     staleTime: 60 * 1000,
     gcTime: 500 * 1000,
     initialPageParam: { meta: { key: null, effectiveSize: 20 } },

--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -357,16 +357,8 @@ export default function Header() {
   );
 
   const disconnect = useCallback(async () => {
-    console.log('before disconnect', webSocketClient, webSocketClientConnected);
-
     if (!isNull(webSocketClient) && webSocketClientConnected) {
-      console.log('강제 연결 종료');
       await webSocketClient.deactivate();
-      console.log(
-        'after disconnect',
-        webSocketClient,
-        webSocketClientConnected,
-      );
     }
   }, [webSocketClient, webSocketClientConnected]);
 

--- a/src/app/(chat)/layout.tsx
+++ b/src/app/(chat)/layout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Header from './_components/organisms/Header';
 import MessageInput from './_components/molecules/MessageInput';
 import AgoraSideBar from './_components/templates/AgoraSideBar';
+import ChatPageLoadConfig from '../config/ChatPageLoadConfig';
 
 type Props = {
   children: React.ReactNode;
@@ -11,14 +12,16 @@ export default function Layout({ children }: Props) {
   return (
     <div className="w-full overflow-y-hidden overflow-x-hidden h-dvh flex justify-center items-center xl:w-[1580px] relative">
       <section className="w-full flex flex-1 h-dvh max-lg:pb-3rem min-w-270 flex-grow max-width-screen absolute top-0">
-        <section className="flex flex-1 flex-col w-full relative h-dvh">
-          <section className="sticky w-full top-0 bg-white dark:bg-dark-bg-light pt-10 min-w-270 border-b-1 border-gray-200 dark:border-dark-light-300">
-            <Header />
+        <ChatPageLoadConfig>
+          <section className="flex flex-1 flex-col w-full relative h-dvh">
+            <section className="sticky w-full top-0 bg-white dark:bg-dark-bg-light pt-10 min-w-270 border-b-1 border-gray-200 dark:border-dark-light-300">
+              <Header />
+            </section>
+            {children}
+            <MessageInput />
           </section>
-          {children}
-          <MessageInput />
-        </section>
-        <AgoraSideBar />
+          <AgoraSideBar />
+        </ChatPageLoadConfig>
       </section>
     </div>
   );

--- a/src/app/(main)/_components/atoms/CategoryAgoraNowTitle.tsx
+++ b/src/app/(main)/_components/atoms/CategoryAgoraNowTitle.tsx
@@ -25,9 +25,19 @@ function CategoryAgoraNowTitle({ tabStatus, searchParams }: ActiveHeaderProps) {
     [queryClient],
   );
 
-  const handleClickRefresh = () => {
+  const handleClickRefresh = async () => {
     const category = params.get('category') ?? '';
     const status = params.get('status') ?? 'active';
+
+    await queryClient.resetQueries({
+      queryKey: [
+        'agoras',
+        'search',
+        'category',
+        { ...searchParams, status, category },
+      ],
+      exact: false,
+    });
 
     queryClient.invalidateQueries({
       queryKey: [

--- a/src/app/(main)/_components/atoms/CategoryAgoraNowTitle.tsx
+++ b/src/app/(main)/_components/atoms/CategoryAgoraNowTitle.tsx
@@ -1,3 +1,4 @@
+import { SearchParams } from '@/app/model/Agora';
 import RefreshIcon from '@/assets/icons/RefreshIcon';
 import { getCategoryAgoraListBasicQueryKey } from '@/constants/queryKey';
 import { useQueryClient } from '@tanstack/react-query';
@@ -6,11 +7,12 @@ import React, { useCallback } from 'react';
 
 type ActiveHeaderProps = {
   tabStatus: string;
+  searchParams: SearchParams;
 };
 
-function CategoryAgoraNowTitle({ tabStatus }: ActiveHeaderProps) {
+function CategoryAgoraNowTitle({ tabStatus, searchParams }: ActiveHeaderProps) {
   const queryClient = useQueryClient();
-  const searchParams = useSearchParams();
+  const params = useSearchParams();
 
   const handleKeyDownRefresh = useCallback(
     (e: React.KeyboardEvent) => {
@@ -23,18 +25,20 @@ function CategoryAgoraNowTitle({ tabStatus }: ActiveHeaderProps) {
     [queryClient],
   );
 
-  const handleClickRefresh = useCallback(() => {
-    const category = searchParams.get('category') ?? '';
-    const status = searchParams.get('status') ?? 'active';
+  const handleClickRefresh = () => {
+    const category = params.get('category') ?? '';
+    const status = params.get('status') ?? 'active';
 
-    queryClient.resetQueries({
-      queryKey: getCategoryAgoraListBasicQueryKey(),
-    });
     queryClient.invalidateQueries({
-      queryKey: ['agoras', 'search', 'category', { status, category }],
-      type: 'all',
+      queryKey: [
+        'agoras',
+        'search',
+        'category',
+        { ...searchParams, status, category },
+      ],
+      exact: false,
     });
-  }, [queryClient]);
+  };
 
   return (
     tabStatus === 'active' && (

--- a/src/app/(main)/_components/molecules/AgoraListDecider.tsx
+++ b/src/app/(main)/_components/molecules/AgoraListDecider.tsx
@@ -46,6 +46,7 @@ export default function AgoraListDecider({ searchParams }: Props) {
       tabStatus: state.tabStatus,
     })),
   );
+
   const { kicked, reset } = useKickedStore(
     useShallow((state) => ({
       kicked: state.kicked,
@@ -94,7 +95,10 @@ export default function AgoraListDecider({ searchParams }: Props) {
         </>
       )}
       <ErrorBoundary FallbackComponent={FallbackComponent}>
-        <CategoryAgoraNowTitle tabStatus={tabStatus} />
+        <CategoryAgoraNowTitle
+          tabStatus={tabStatus}
+          searchParams={searchParams}
+        />
         <CategoryAgoraList searchParams={searchParams} />
       </ErrorBoundary>
     </>

--- a/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
@@ -82,17 +82,6 @@ export default function CategoryAgoraList({ searchParams }: Props) {
     },
   });
 
-  console.log(
-    'searchParams',
-    searchParams,
-    'tabStatus',
-    tabStatus,
-    'selectedCategory',
-    selectedCategory,
-  );
-
-  console.log('data', data);
-
   const loadNextPage = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {
       fetchNextPage();

--- a/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
@@ -82,6 +82,17 @@ export default function CategoryAgoraList({ searchParams }: Props) {
     },
   });
 
+  console.log(
+    'searchParams',
+    searchParams,
+    'tabStatus',
+    tabStatus,
+    'selectedCategory',
+    selectedCategory,
+  );
+
+  console.log('data', data);
+
   const loadNextPage = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
@@ -95,9 +106,11 @@ export default function CategoryAgoraList({ searchParams }: Props) {
 
   useEffect(() => {
     // 초기 데이터 호출 후 카테고리 변경 시 데이터 재호출
-    queryClient.resetQueries({
+    queryClient.removeQueries({
       queryKey: getCategoryAgoraListBasicQueryKey(),
+      exact: false,
     });
+
     queryClient.invalidateQueries({
       queryKey: [
         'agoras',
@@ -105,6 +118,7 @@ export default function CategoryAgoraList({ searchParams }: Props) {
         'category',
         { ...searchParams, status: tabStatus, category: selectedCategory },
       ],
+      exact: false,
     });
   }, [selectedCategory, queryClient, tabStatus, searchParams, refetch]);
 

--- a/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/CategoryAgoraList.tsx
@@ -105,21 +105,25 @@ export default function CategoryAgoraList({ searchParams }: Props) {
   );
 
   useEffect(() => {
-    // 초기 데이터 호출 후 카테고리 변경 시 데이터 재호출
-    queryClient.removeQueries({
-      queryKey: getCategoryAgoraListBasicQueryKey(),
-      exact: false,
-    });
+    const queryDataCacheRefresh = async () => {
+      // 초기 데이터 호출 후 카테고리 변경 시 데이터 재호출
+      await queryClient.resetQueries({
+        queryKey: getCategoryAgoraListBasicQueryKey(),
+        exact: false,
+      });
 
-    queryClient.invalidateQueries({
-      queryKey: [
-        'agoras',
-        'search',
-        'category',
-        { ...searchParams, status: tabStatus, category: selectedCategory },
-      ],
-      exact: false,
-    });
+      queryClient.invalidateQueries({
+        queryKey: [
+          'agoras',
+          'search',
+          'category',
+          { ...searchParams, status: tabStatus, category: selectedCategory },
+        ],
+        exact: false,
+      });
+    };
+
+    queryDataCacheRefresh();
   }, [selectedCategory, queryClient, tabStatus, searchParams, refetch]);
 
   useEffect(() => {

--- a/src/app/(main)/_lib/postEnterAgoraInfo.ts
+++ b/src/app/(main)/_lib/postEnterAgoraInfo.ts
@@ -1,11 +1,7 @@
 import { ParticipationPosition } from '@/app/model/Agora';
 import { AGORA_POSITION, AGORA_STATUS } from '@/constants/agora';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
-import {
-  AUTH_MESSAGE,
-  SIGNIN_REQUIRED,
-  TOKEN_EXPIRED,
-} from '@/constants/authErrorMessage';
+import { AUTH_MESSAGE, SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { getSession } from '@/serverActions/auth';
 import {
   AGORA_ENTER,
@@ -75,11 +71,9 @@ export const postEnterAgoraInfo = async ({ info, agoraId }: Props) => {
         throw new Error(AGORA_ENTER.NOT_ALLOWED_POSITION);
       }
     } else if (res.error.code === 1002) {
-      if (res.error.message === TOKEN_EXPIRED) {
-        throw new Error(res.error.message);
+      if (res.error.message === AGORA_ENTER.SERVER_RESPONSE_CLOSED_AGORA) {
+        return AGORA_STATUS.CLOSED;
       }
-
-      return AGORA_STATUS.CLOSED;
     } else if (res.error.code === 1004) {
       if (
         splitMessage(res.error.message) ===

--- a/src/app/(main)/_lib/postEnterAgoraInfo.ts
+++ b/src/app/(main)/_lib/postEnterAgoraInfo.ts
@@ -1,7 +1,11 @@
 import { ParticipationPosition } from '@/app/model/Agora';
 import { AGORA_POSITION, AGORA_STATUS } from '@/constants/agora';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
-import { SIGNIN_REQUIRED, TOKEN_EXPIRED } from '@/constants/authErrorMessage';
+import {
+  AUTH_MESSAGE,
+  SIGNIN_REQUIRED,
+  TOKEN_EXPIRED,
+} from '@/constants/authErrorMessage';
 import { getSession } from '@/serverActions/auth';
 import {
   AGORA_ENTER,

--- a/src/app/config/ChatPageLoadConfig.tsx
+++ b/src/app/config/ChatPageLoadConfig.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useAgora } from '@/store/agora';
+import { useEnter } from '@/store/enter';
+import isNull from '@/utils/validation/validateIsNull';
+import { useSession } from 'next-auth/react';
+import { usePathname } from 'next/navigation';
+import React, { useEffect } from 'react';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function ChatPageLoadConfig({ children }: Props) {
+  const { data: session } = useSession();
+  const { title: agoraTitle, id: prevAgoraId } = useAgora().enterAgora;
+  const agoraInfoReset = useAgora().enterAgoraReset;
+  const userProfilReset = useEnter().reset;
+  const agoraId = usePathname().split('/').at(-1);
+
+  useEffect(() => {
+    // 채팅방으로 페이지 이동시 다른 탭에서 이미 입장한 유저라면(session storage 데이터 없음) 내보내기
+    if (typeof window !== 'undefined' && !isNull(session)) {
+      const entries = performance.getEntriesByType(
+        'navigation',
+      )[0] as PerformanceNavigationTiming;
+
+      if (entries?.type === 'navigate' && isNull(agoraTitle)) {
+        // 채팅방 입장하기 페이지 띄우기
+        window.location.replace(`/flow/enter-agora/${agoraId}`);
+      } else if (entries?.type === 'navigate' && !isNull(agoraTitle)) {
+        // 채팅방에서 다른 채팅방으로 이동, storage 데이터 초기화 후 입장하기 페이지 띄우기
+        agoraInfoReset();
+        userProfilReset();
+
+        useAgora.persist.rehydrate();
+        useEnter.persist.rehydrate();
+
+        window.location.replace(`/flow/enter-agora/${agoraId}`);
+      }
+    }
+  }, [session]);
+
+  const isSameAgora = (prevId: number, currentId: string | undefined) => {
+    if (prevId === Number(currentId)) {
+      return true;
+    }
+    return false;
+  };
+
+  if (
+    isNull(session) ||
+    isNull(agoraTitle) ||
+    !isSameAgora(prevAgoraId, agoraId)
+  ) {
+    return <div className="text-white">페이지 로딩 중</div>;
+  }
+
+  return children;
+}

--- a/src/app/config/ChatPageLoadConfig.tsx
+++ b/src/app/config/ChatPageLoadConfig.tsx
@@ -6,6 +6,7 @@ import isNull from '@/utils/validation/validateIsNull';
 import { useSession } from 'next-auth/react';
 import { usePathname } from 'next/navigation';
 import React, { useEffect } from 'react';
+import ChatPageLoading from '../(chat)/_components/atoms/ChatPageLoading';
 
 type Props = {
   children: React.ReactNode;
@@ -53,7 +54,7 @@ export default function ChatPageLoadConfig({ children }: Props) {
     isNull(agoraTitle) ||
     !isSameAgora(prevAgoraId, agoraId)
   ) {
-    return <div className="text-white">페이지 로딩 중</div>;
+    return <ChatPageLoading />;
   }
 
   return children;

--- a/src/constants/responseErrorMessage.ts
+++ b/src/constants/responseErrorMessage.ts
@@ -46,6 +46,7 @@ export const AGORA_ENTER = {
   UNKNOWN_ERROR: '알 수 없는 에러가 발생했습니다.',
   SERVER_RESPONSE_ALREADY_PARTICIPATED: 'User has already participated',
   SERVER_RESPONSE_NICKNAME_DUPLICATED: 'The nickname is already in use',
+  SERVER_RESPONSE_CLOSED_AGORA: 'Agora is closed',
 } as const;
 
 export const AGORA_USER = {

--- a/src/hooks/useUnloadDisconnectSocket.tsx
+++ b/src/hooks/useUnloadDisconnectSocket.tsx
@@ -26,11 +26,15 @@ export function useUnloadDisconnectSocket({ mutation }: Props) {
   };
 
   useEffect(() => {
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    window.addEventListener('unload', handleUnload);
+    if (window) {
+      window.addEventListener('beforeunload', handleBeforeUnload);
+      window.addEventListener('unload', handleUnload);
+    }
     return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-      window.removeEventListener('unload', handleUnload);
+      if (window) {
+        window.removeEventListener('beforeunload', handleBeforeUnload);
+        window.removeEventListener('unload', handleUnload);
+      }
     };
   }, [mutation, handleUnload]);
 }

--- a/src/store/agora.ts
+++ b/src/store/agora.ts
@@ -1,5 +1,6 @@
 import { COLOR } from '@/constants/consts';
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 type Agora = {
   id: number;
@@ -26,48 +27,62 @@ interface AgoraState {
   setEnterAgora: (agora: EnterAgora) => void;
   setSelectedAgora: (agora: Agora) => void;
   reset: () => void;
+  enterAgoraReset: () => void;
 }
 
+const storageKey = 'athens-chat-info';
+
+const selectedAgoraInitialState: Agora = {
+  id: 0,
+  thumbnail: '',
+  title: '',
+  status: '',
+  agoraColor: COLOR[0].value,
+};
+
+const enterAgoraInitialState: EnterAgora = {
+  id: 0,
+  userId: 0,
+  thumbnail: '',
+  title: '',
+  status: '',
+  role: '',
+  isCreator: false,
+  agoraColor: COLOR[0].value,
+};
+
 // eslint-disable-next-line import/prefer-default-export
-export const useAgora = create<AgoraState>((set) => ({
-  selectedAgora: {
-    id: 0,
-    thumbnail: '',
-    title: '',
-    status: '',
-    agoraColor: COLOR[0].value,
-  },
-  enterAgora: {
-    id: 0,
-    userId: 0,
-    thumbnail: '',
-    title: '',
-    status: '',
-    role: '',
-    isCreator: false,
-    agoraColor: COLOR[0].value,
-  },
-  setEnterAgora(agora: EnterAgora) {
-    set((state) => ({
-      enterAgora: {
-        ...state.enterAgora,
-        ...agora,
-        userId: agora.userId ?? 0,
+export const useAgora = create(
+  persist<AgoraState>(
+    (set) => ({
+      selectedAgora: selectedAgoraInitialState,
+      enterAgora: enterAgoraInitialState,
+      setEnterAgora(agora: EnterAgora) {
+        set((state) => ({
+          enterAgora: {
+            ...state.enterAgora,
+            ...agora,
+            userId: agora.userId ?? 0,
+          },
+        }));
       },
-    }));
-  },
-  setSelectedAgora(agora: Agora) {
-    set({ selectedAgora: agora });
-  },
-  reset() {
-    set({
-      selectedAgora: {
-        id: 0,
-        thumbnail: '',
-        title: '',
-        status: '',
-        agoraColor: COLOR[0].value,
+      setSelectedAgora(agora: Agora) {
+        set({ selectedAgora: agora });
       },
-    });
-  },
-}));
+      reset() {
+        set({
+          selectedAgora: selectedAgoraInitialState,
+        });
+      },
+      enterAgoraReset() {
+        set({
+          enterAgora: enterAgoraInitialState,
+        });
+      },
+    }),
+    {
+      name: storageKey,
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+);

--- a/src/store/enter.ts
+++ b/src/store/enter.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { ParticipationPosition, ProfileImage } from '@/app/model/Agora';
 import { AGORA_POSITION } from '@/constants/agora';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 interface EnterState {
   nickname: string;
@@ -31,26 +32,34 @@ const initialState: EnterState = {
   reset: () => {},
 };
 
+const storageKey = 'athens-chat-user-profile';
+
 // eslint-disable-next-line import/prefer-default-export
 export const useEnter = create(
-  immer<EnterState>((set) => ({
-    ...initialState,
-    setMessage: (message: string) => set({ message }),
-    setSelectedPosition: (selectedPosition: ParticipationPosition) =>
-      set({ selectedPosition }),
-    setNickname: (nickname: string) => set({ nickname }),
-    setProfileImage: (profileImage: ProfileImage) =>
-      set({ selectedProfileImage: profileImage }),
-    reset: () =>
-      set({
-        nickname: '',
-        message: '관찰자는 프로필을 설정할 수 없습니다.',
-        selectedProfileImage: {
-          id: 1,
-          name: '도끼 든 회색 곰',
-          file: 'bear.png',
-        },
-        selectedPosition: AGORA_POSITION.OBSERVER,
-      }),
-  })),
+  persist(
+    immer<EnterState>((set) => ({
+      ...initialState,
+      setMessage: (message: string) => set({ message }),
+      setSelectedPosition: (selectedPosition: ParticipationPosition) =>
+        set({ selectedPosition }),
+      setNickname: (nickname: string) => set({ nickname }),
+      setProfileImage: (profileImage: ProfileImage) =>
+        set({ selectedProfileImage: profileImage }),
+      reset: () =>
+        set({
+          nickname: '',
+          message: '관찰자는 프로필을 설정할 수 없습니다.',
+          selectedProfileImage: {
+            id: 1,
+            name: '도끼 든 회색 곰',
+            file: 'bear.png',
+          },
+          selectedPosition: AGORA_POSITION.OBSERVER,
+        }),
+    })),
+    {
+      name: storageKey,
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
 );


### PR DESCRIPTION
### 🔗 Linked Issue

### 🛠 개발 기능

- 채팅방 입장하기 API 호출 후 종료된 아고라일 시 종료된 아고라라는 알림 리턴하도록 수정
- 채팅방 새로고침시 기존 프로필 유지하도록 개선

### 🧩 해결 방법

- `performance.getEntriesByType`을 사용하여 새로고침인지, 다른 페이지에서 이동한 것인지 판별하여 새로고침을 인식하도록 했습니다.
- zustand 전역 상태로 관리 중이던 유저 프로필 정보를 `persist`로 `sessionStorage`에 저장하여 새로고침 후에도 데이터를 유지하도록 수정하였습니다.
- storage는 클라이언트 사이드에서만 사용할 수 있으므로, 세션과 유저 정보를 불러오는 서버 사이드 렌더링 시간 동안은 채팅방의 빈 레이아웃을 보여주도록 하였습니다.

### 🔍 리뷰 포인트

- 

### 참고
- [페이지 새로고침 여부 확인 방법](https://seeminglyjs.tistory.com/490)

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
