### PR TITLE
첫 렌더링 후 meta로 테마 설정 추가

### DIFF
--- a/src/app/_components/utils/SetTheme.tsx
+++ b/src/app/_components/utils/SetTheme.tsx
@@ -9,7 +9,7 @@ type Props = {
 export default function SetTheme({ theme }: Props) {
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
-  }, []);
+  }, [theme]);
 
   return null;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import { Noto_Sans_KR } from 'next/font/google';
 import Script from 'next/script';
 import { FetchWrapper } from '@/lib/fetchWrapper';
 import { getThemeValue } from '@/serverActions/theme';
-import { THEME } from '@/constants/theme';
+import { THEME, THEME_CONTENT } from '@/constants/theme';
 import MSWComponent from './config/MSWComponent';
 import RQProvider from './config/RQProvider';
 import ServiceWorkerRegistration from './config/ServiceWorkerRegistration';
@@ -14,7 +14,7 @@ import SetTheme from './_components/utils/SetTheme';
 import AuthSession from './_components/utils/AuthSession';
 
 export const viewport: Viewport = {
-  themeColor: '#3A3A3B',
+  themeColor: '#ffffff',
   width: 'device-width',
   initialScale: 1,
   minimumScale: 1,
@@ -56,6 +56,12 @@ export default async function RootLayout({
   return (
     <html lang="ko" className={theme === THEME.LIGHT ? '' : theme}>
       <link rel="manifest" href="/manifest.json" />
+      <meta
+        name="theme-color"
+        content={
+          theme === THEME.LIGHT ? THEME_CONTENT.LIGHT : THEME_CONTENT.DARK
+        }
+      />
       <body
         className={`h-dvh inset-y-full under-large:w-full min-w-300 lg:flex scrollbar-hide overflow-x-hidden overflow-y-hidden justify-center items-start w-full dark:bg-dark-bg-light ${noto.className} antialiased`}
       >


### PR DESCRIPTION
### 🔗 Linked Issue

### 🛠 개발 기능

- 테마 스위치 버튼을 누를 때만 meta 태그가 추가되던 것을 첫 렌더링 후 바로 추가되도록 수정

### 🧩 해결 방법

- setTheme에 테마 값 설정할 때 같이 설정해주도록 하였습니다.

### 🔍 리뷰 포인트

- 

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
