### PR TITLE
종료/활성화 채팅방에서의 새로고침 시 자동 재입장 되도록 로직 수정

### DIFF
--- a/src/app/(chat)/_components/atoms/ChatPageLoading.tsx
+++ b/src/app/(chat)/_components/atoms/ChatPageLoading.tsx
@@ -5,7 +5,7 @@ import BackButton from '@/app/_components/atoms/BackButton';
 import Loading from '@/app/_components/atoms/loading';
 import HamburgerIcon from '@/assets/icons/HamburgerIcon';
 import SendIcon from '@/assets/icons/SendIcon';
-import ShareButton from '../molecules/ShareButton';
+import ShareButton from './ShareButton';
 import DiscussionStatus from '../molecules/DiscussionStatus';
 import AgoraInfo from '../molecules/AgoraInfo';
 

--- a/src/app/(chat)/_components/atoms/HamburgerButton.tsx
+++ b/src/app/(chat)/_components/atoms/HamburgerButton.tsx
@@ -16,7 +16,12 @@ export default function HamburgerButton({
   };
 
   return (
-    <button aria-label="메뉴 열기" onClick={handleClick} type="button">
+    <button
+      className="pl-5"
+      aria-label="메뉴 열기"
+      onClick={handleClick}
+      type="button"
+    >
       <HamburgerIcon className="w-20 lg:w-22 cursor-pointer" />
     </button>
   );

--- a/src/app/(chat)/_components/atoms/ShareButton.tsx
+++ b/src/app/(chat)/_components/atoms/ShareButton.tsx
@@ -5,7 +5,7 @@ import ShareIcon from '@/assets/icons/ShareIcon';
 import { useParams, useRouter } from 'next/navigation';
 import React, { MouseEventHandler, useState } from 'react';
 import { BottomSheet } from 'react-spring-bottom-sheet';
-import SocialShareLogos from '../atoms/SocialShareLogos';
+import SocialShareLogos from './SocialShareLogos';
 
 import 'react-spring-bottom-sheet/dist/style.css';
 
@@ -41,7 +41,7 @@ export default function ShareButton({ title }: Props) {
       type="button"
       aria-label="SNS 공유하기"
       onClick={shareSNS}
-      className="cursor-pointer pr-5"
+      className="cursor-pointer"
     >
       <ShareIcon className="w-18 lg:w-20 mr-1rem under-mobile:mr-0.5rem" />
       <BottomSheet onDismiss={handleDismiss} open={open}>

--- a/src/app/(chat)/_components/molecules/MenuItems.tsx
+++ b/src/app/(chat)/_components/molecules/MenuItems.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ShareButton from '../atoms/ShareButton';
+import HamburgerButton from '../atoms/HamburgerButton';
+
+type Props = {
+  memoizedTitle: string;
+  toggle: () => void;
+  refetchAgoraUserList: () => void;
+  isClosed: boolean;
+};
+
+function MenuItems({
+  memoizedTitle,
+  toggle,
+  refetchAgoraUserList,
+  isClosed,
+}: Props) {
+  return (
+    <div className="flex justify-end items-center mr-0.5rem">
+      <ShareButton title={memoizedTitle} />
+      {!isClosed && (
+        <HamburgerButton
+          toggleMenu={toggle}
+          refetchUserList={refetchAgoraUserList}
+        />
+      )}
+    </div>
+  );
+}
+
+export default React.memo(MenuItems);

--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -189,8 +189,8 @@ export default function Header() {
     return (
       (navigator.onLine &&
         URL.SOCKET_URL !== '' &&
-        enterAgora.status === 'QUEUED') ||
-      enterAgora.status === 'RUNNING'
+        enterAgora.status === AGORA_STATUS.QUEUED) ||
+      enterAgora.status === AGORA_STATUS.RUNNING
     );
   };
 

--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -38,42 +38,24 @@ import accessMessageConfig from '@/lib/accessMessageConfig';
 import { useWebSocketClient } from '@/store/webSocket';
 import { useEnter } from '@/store/enter';
 import BackButton from '../../../_components/atoms/BackButton';
-import ShareButton from '../molecules/ShareButton';
 import AgoraInfo from '../molecules/AgoraInfo';
-import HamburgerButton from '../atoms/HamburgerButton';
 import DiscussionStatus from '../molecules/DiscussionStatus';
 import patchChatExit from '../../_lib/patchChatExit';
 import SocketErrorHandler from '../../utils/SocketErrorHandler';
-
-type Props = {
-  memoizedTitle: string;
-  toggle: () => void;
-  refetchAgoraUserList: () => void;
-};
-
-const MenuItems = React.memo(function MenuItems({
-  memoizedTitle,
-  toggle,
-  refetchAgoraUserList,
-}: Props) {
-  return (
-    <div className="flex justify-end items-center mr-0.5rem">
-      <ShareButton title={memoizedTitle} />
-      <HamburgerButton
-        toggleMenu={toggle}
-        refetchUserList={refetchAgoraUserList}
-      />
-    </div>
-  );
-});
+import MenuItems from '../molecules/MenuItems';
 
 export default function Header() {
   const { toggle } = useSidebarStore(
     useShallow((state) => ({ toggle: state.toggle })),
   );
-  const { enterAgora, reset: selectedAgoraReset } = useAgora(
+  const {
+    enterAgora,
+    reset: selectedAgoraReset,
+    enterAgoraReset,
+  } = useAgora(
     useShallow((state) => ({
       enterAgora: state.enterAgora,
+      enterAgoraReset: state.enterAgoraReset,
       reset: state.reset,
     })),
   );
@@ -149,7 +131,10 @@ export default function Header() {
   };
 
   const callChatExitAPI = async () => {
-    return patchChatExit({ agoraId });
+    if (enterAgora.status !== AGORA_STATUS.CLOSED) {
+      return patchChatExit({ agoraId });
+    }
+    return () => {};
   };
 
   const onSuccessChatExit = (response: any) => {
@@ -177,8 +162,9 @@ export default function Header() {
   const handleAgoraExit = () => {
     if (enterAgora.status === AGORA_STATUS.CLOSED) {
       selectedAgoraReset();
+      enterAgoraReset();
 
-      router.replace(homeSegmentKey);
+      onSuccessChatExit(true);
     } else if (
       enterAgora.status === AGORA_STATUS.RUNNING ||
       enterAgora.status === AGORA_STATUS.QUEUED
@@ -201,9 +187,10 @@ export default function Header() {
 
   const isPossibleConnect = () => {
     return (
-      navigator.onLine &&
-      URL.SOCKET_URL !== '' &&
-      enterAgora.status !== AGORA_STATUS.CLOSED
+      (navigator.onLine &&
+        URL.SOCKET_URL !== '' &&
+        enterAgora.status === 'QUEUED') ||
+      enterAgora.status === 'RUNNING'
     );
   };
 
@@ -506,6 +493,7 @@ export default function Header() {
 
   useUnloadDisconnectSocket({
     mutation: mutation.mutate,
+    agoraStatus: enterAgora.status,
   });
 
   const memoizedTitle = useMemo(() => {
@@ -527,6 +515,7 @@ export default function Header() {
           memoizedTitle={memoizedTitle}
           toggle={toggle}
           refetchAgoraUserList={refetchAgoraUserList}
+          isClosed={enterAgora.status === AGORA_STATUS.CLOSED}
         />
       </div>
       <div className="flex justify-center items-center">

--- a/src/app/(main)/_components/atoms/CategoryAgora.tsx
+++ b/src/app/(main)/_components/atoms/CategoryAgora.tsx
@@ -24,15 +24,14 @@ type Props = {
 
 function CategoryAgora({ agora, className }: Props) {
   const router = useRouter();
-  const { setSelectedAgora, setEnterAgora, selectedAgora } = useAgora();
+  const { setSelectedAgora, setEnterAgora } = useAgora();
   const [selectedColor, setSelectedColor] = useState(COLOR[0].value);
+  const [isClicked, setIsClicked] = useState(false);
 
   const { data, isLoading } = useQuery({
     queryKey: getClosedAgoraQueryKey(agora.id),
     queryFn: () => getEnterClosedAgoraStatus(agora.id),
-    enabled:
-      agora.id === selectedAgora.id &&
-      selectedAgora.status === AGORA_STATUS.CLOSED,
+    enabled: agora.status === AGORA_STATUS.CLOSED && isClicked,
   });
 
   const routeAgoraPage = useCallback(() => {
@@ -54,6 +53,8 @@ function CategoryAgora({ agora, className }: Props) {
 
   // TODO: 아고라 id를 받아서 해당 아고라로 이동
   const handleEnterAgora = () => {
+    setIsClicked(true);
+
     setSelectedAgora({
       id: agora.id,
       thumbnail: agora.imageUrl,
@@ -61,6 +62,8 @@ function CategoryAgora({ agora, className }: Props) {
       status: agora.status,
       agoraColor: agora.agoraColor,
     });
+
+    setAgoraData();
 
     if (
       agora.status === AGORA_STATUS.QUEUED ||
@@ -73,14 +76,14 @@ function CategoryAgora({ agora, className }: Props) {
   useEffect(() => {
     // 종료된 아고라 입장 시 아고라 데이터 설정
     if (
-      selectedAgora.status === AGORA_STATUS.CLOSED &&
+      agora.status === AGORA_STATUS.CLOSED &&
       !isNull(data) &&
-      !isLoading
+      !isLoading &&
+      isClicked
     ) {
-      setAgoraData();
       routeAgoraPage();
     }
-  }, [data, isLoading, selectedAgora.status]);
+  }, [data, isLoading, isClicked]);
 
   useEffect(() => {
     setSelectedColor(

--- a/src/app/(main)/_components/atoms/KeywordAgora.tsx
+++ b/src/app/(main)/_components/atoms/KeywordAgora.tsx
@@ -160,7 +160,7 @@ export default function KeywordAgora({ agora }: Props) {
           )}
           {agora.status !== AGORA_STATUS.CLOSED && (
             <span
-              className={`absolute top-2 left-50 inline-block w-13 h-13 ${agora.status === 'queued' ? 'bg-athens-button' : 'bg-red-400'} rounded-full ml-3`}
+              className={`absolute top-2 left-50 inline-block w-13 h-13 ${agora.status === AGORA_STATUS.QUEUED ? 'bg-athens-button' : 'bg-red-400'} rounded-full ml-3`}
             />
           )}
         </div>

--- a/src/app/(main)/_lib/getAgoraTitle.ts
+++ b/src/app/(main)/_lib/getAgoraTitle.ts
@@ -7,9 +7,10 @@ import {
   AGORA_INFO,
   NETWORK_ERROR_MESSAGE,
 } from '@/constants/responseErrorMessage';
+import { Status } from '@/app/model/Agora';
 
 export const getAgoraTitle: QueryFunction<
-  { title: string; status: string; imageUrl: string; agoraColor: string },
+  { title: string; status: Status | ''; imageUrl: string; agoraColor: string },
   [_1: string, _2: string]
 > = async ({ queryKey }) => {
   const [_, agoraId] = queryKey;

--- a/src/app/(main)/login/route.ts
+++ b/src/app/(main)/login/route.ts
@@ -6,7 +6,7 @@ export async function GET(request: Request) {
   const error = searchParams.get('error');
 
   if (error) {
-    return NextResponse.redirect('/');
+    return NextResponse.redirect(`${process.env.NEXT_CLIENT_URL}/`);
   }
 
   return NextResponse.redirect(`${origin}/login/auth?user=${token}`);

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -29,7 +29,7 @@ export default async function Page() {
   const session = await getSession();
 
   if (!isNull(session?.user)) {
-    redirect(homeSegmentKey);
+    redirect(`${process.env.NEXT_CLIENT_URL}/${homeSegmentKey}`);
     return null;
   }
 

--- a/src/app/(main)/user-info/_lib/postLogout.ts
+++ b/src/app/(main)/user-info/_lib/postLogout.ts
@@ -1,4 +1,4 @@
-import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
+import { AUTH_MESSAGE, SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { LOGOUT_ERROR_MESSAGE } from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
@@ -22,6 +22,8 @@ const postLogout = async () => {
   if (!res.ok && res.error?.message) {
     if (res.error.code === 1201) {
       throw new Error(LOGOUT_ERROR_MESSAGE.EXPIRED_TOKEN);
+    } else if (AUTH_MESSAGE.includes(res.error.message)) {
+      throw new Error(res.error.message);
     }
 
     if (!res.error) {

--- a/src/app/_components/utils/SessionNavigationObserver.tsx
+++ b/src/app/_components/utils/SessionNavigationObserver.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import usePreviousPage from '@/hooks/usePreviousPage';
+import React, { Suspense } from 'react';
+
+function SessionNavigationObserver() {
+  usePreviousPage();
+
+  return null;
+}
+
+function SuspensePreviousPageComponent() {
+  return (
+    <Suspense fallback={null}>
+      <SessionNavigationObserver />
+    </Suspense>
+  );
+}
+
+export default SuspensePreviousPageComponent;

--- a/src/app/_components/utils/SetChatInfoReset.tsx
+++ b/src/app/_components/utils/SetChatInfoReset.tsx
@@ -5,32 +5,31 @@ import { useEnter } from '@/store/enter';
 import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import isNull from '@/utils/validation/validateIsNull';
+import { usePathname } from 'next/navigation';
 
 export default function SetChatInfoReset() {
   const {
     enterAgoraReset: agoraInfoReset,
     reset: selectedAgoraInfoReset,
-    enterAgora,
+    selectedAgora,
   } = useAgora(
     useShallow((state) => ({
-      enterAgora: state.enterAgora,
+      selectedAgora: state.selectedAgora,
       enterAgoraReset: state.enterAgoraReset,
       reset: state.reset,
     })),
   );
   const { reset: userProfileReset } = useEnter();
+  const pathname = usePathname();
 
   useEffect(() => {
     // 채팅방 정보 및 유저 채팅 프로필 정보 초기화
-    if (
-      typeof window !== 'undefined' &&
-      !window.location.pathname.startsWith('/flow')
-    ) {
+    if (typeof window !== 'undefined' && !pathname.startsWith('/flow')) {
       const entries = performance.getEntriesByType(
         'navigation',
       )[0] as PerformanceNavigationTiming;
 
-      if (entries?.type === 'navigate' && !isNull(enterAgora.id)) {
+      if (entries?.type === 'navigate' && !isNull(selectedAgora.id)) {
         // 채팅방에서 다른 채팅방으로 이동, storage 데이터 초기화 후 입장하기 페이지 띄우기
         agoraInfoReset();
         userProfileReset();
@@ -40,7 +39,7 @@ export default function SetChatInfoReset() {
         useEnter.persist.rehydrate();
       }
     }
-  }, [agoraInfoReset, enterAgora.id, selectedAgoraInfoReset, userProfileReset]);
+  }, [agoraInfoReset, pathname, selectedAgoraInfoReset, userProfileReset]);
 
   return null;
 }

--- a/src/app/config/ChatPageLoadConfig.tsx
+++ b/src/app/config/ChatPageLoadConfig.tsx
@@ -11,7 +11,7 @@ import { AGORA_POSITION, AGORA_STATUS } from '@/constants/agora';
 import showToast from '@/utils/showToast';
 import useApiError from '@/hooks/useApiError';
 import {
-  STORAGE_PREVIOUSE_URK_KEY,
+  STORAGE_PREVIOUSE_URL_KEY,
   homeSegmentKey,
 } from '@/constants/segmentKey';
 import { getSelectedAgoraQueryKey as getSelectedAgoraTags } from '@/constants/queryKey';
@@ -121,7 +121,7 @@ export default function ChatPageLoadConfig({ children }: Props) {
         'navigation',
       )[0] as PerformanceNavigationTiming;
       const sessionNavigatorPrevious = sessionStorage.getItem(
-        STORAGE_PREVIOUSE_URK_KEY,
+        STORAGE_PREVIOUSE_URL_KEY,
       );
 
       const previousUrl = `${window.location.origin}${sessionNavigatorPrevious ?? ''}`;
@@ -132,8 +132,8 @@ export default function ChatPageLoadConfig({ children }: Props) {
         hasMutated.current = true;
         // 기존 아고라가 ACTIVE라면 재입장 API 호출
         if (
-          selectedAgora.status === 'QUEUED' ||
-          selectedAgora.status === 'RUNNING'
+          selectedAgora.status === AGORA_STATUS.QUEUED ||
+          selectedAgora.status === AGORA_STATUS.RUNNING
         ) {
           activeAgoraEnterMutation.mutate();
         }
@@ -155,7 +155,7 @@ export default function ChatPageLoadConfig({ children }: Props) {
   useEffect(() => {
     if (!isNull(agoraInfo)) {
       // CLOSED AGORA일 때, 종료된 아고라 showToast 띄우기
-      if (agoraInfo.status === 'CLOSED') {
+      if (agoraInfo.status === AGORA_STATUS.CLOSED) {
         setSelectedAgora({
           id: Number(agoraId),
           thumbnail: '',
@@ -178,7 +178,10 @@ export default function ChatPageLoadConfig({ children }: Props) {
         useEnter.persist.rehydrate();
       }
       // ACTIVE AGORA일 때, /flow 입장하기 모달 출력
-      if (agoraInfo.status === 'QUEUED' || agoraInfo.status === 'RUNNING') {
+      if (
+        agoraInfo.status === AGORA_STATUS.QUEUED ||
+        agoraInfo.status === AGORA_STATUS.RUNNING
+      ) {
         agoraInfoReset();
         selectedAgoraInfoReset();
 
@@ -188,11 +191,12 @@ export default function ChatPageLoadConfig({ children }: Props) {
   }, [agoraInfo]);
 
   const isLoadingInActiveAgora =
-    (selectedAgora.status === 'QUEUED' || selectedAgora.status === 'RUNNING') &&
+    (selectedAgora.status === AGORA_STATUS.QUEUED ||
+      selectedAgora.status === AGORA_STATUS.RUNNING) &&
     activeAgoraEnterMutation.isPending;
 
   const isLoadingInClosedAgora =
-    selectedAgora.status === 'CLOSED' && LoadingGetBasicFacts;
+    selectedAgora.status === AGORA_STATUS.CLOSED && LoadingGetBasicFacts;
 
   if (isNull(session) || isLoadingInActiveAgora || isLoadingInClosedAgora) {
     return <ChatPageLoading />;

--- a/src/app/config/ChatPageLoadConfig.tsx
+++ b/src/app/config/ChatPageLoadConfig.tsx
@@ -6,13 +6,20 @@ import isNull from '@/utils/validation/validateIsNull';
 import { useSession } from 'next-auth/react';
 import { usePathname, useRouter } from 'next/navigation';
 import React, { useEffect, useRef } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { AGORA_POSITION, AGORA_STATUS } from '@/constants/agora';
 import showToast from '@/utils/showToast';
 import useApiError from '@/hooks/useApiError';
-import { homeSegmentKey } from '@/constants/segmentKey';
+import {
+  STORAGE_PREVIOUSE_URK_KEY,
+  homeSegmentKey,
+} from '@/constants/segmentKey';
+import { getSelectedAgoraQueryKey as getSelectedAgoraTags } from '@/constants/queryKey';
+import { COLOR } from '@/constants/consts';
 import { postEnterAgoraInfo } from '../(main)/_lib/postEnterAgoraInfo';
 import ChatPageLoading from '../(chat)/_components/atoms/ChatPageLoading';
+import { AgoraBasicFacts } from '../model/Agora';
+import { getAgoraTitle } from '../(main)/_lib/getAgoraTitle';
 
 type Props = {
   children: React.ReactNode;
@@ -20,8 +27,8 @@ type Props = {
 
 export default function ChatPageLoadConfig({ children }: Props) {
   const { data: session } = useSession();
-  const { title: agoraTitle, id: prevAgoraId } = useAgora().enterAgora;
   const {
+    enterAgora,
     enterAgoraReset: agoraInfoReset,
     reset: selectedAgoraInfoReset,
     setEnterAgora,
@@ -33,6 +40,7 @@ export default function ChatPageLoadConfig({ children }: Props) {
   const router = useRouter();
   const { handleError } = useApiError();
   const hasMutated = useRef(false);
+  const isAccessToAnotherAgora = useRef(false);
 
   const callEnterAgoraAPI = async () => {
     const { selectedProfileImage, selectedPosition, nickname } =
@@ -42,10 +50,10 @@ export default function ChatPageLoadConfig({ children }: Props) {
       nickname,
       role: selectedPosition,
     };
-    return postEnterAgoraInfo({ info, agoraId: prevAgoraId });
+    return postEnterAgoraInfo({ info, agoraId: selectedAgora.id });
   };
 
-  const mutation = useMutation({
+  const activeAgoraEnterMutation = useMutation({
     mutationFn: callEnterAgoraAPI,
     onSuccess: async (response) => {
       if (response) {
@@ -54,7 +62,7 @@ export default function ChatPageLoadConfig({ children }: Props) {
 
           setEnterAgora({
             ...selectedAgora,
-            id: prevAgoraId,
+            id: selectedAgora.id,
             userId: response.userId,
             status: AGORA_STATUS.CLOSED,
             role: AGORA_POSITION.OBSERVER,
@@ -79,8 +87,19 @@ export default function ChatPageLoadConfig({ children }: Props) {
       router.push(homeSegmentKey);
     },
     onError: async (error) => {
-      await handleError(error, mutation.mutate);
+      await handleError(error, activeAgoraEnterMutation.mutate);
     },
+  });
+
+  const {
+    data: agoraInfo,
+    isLoading: LoadingGetBasicFacts,
+  }: { data: AgoraBasicFacts | undefined; isLoading: boolean } = useQuery({
+    queryKey: getSelectedAgoraTags(agoraId || ''),
+    queryFn: (query) => {
+      return getAgoraTitle(query);
+    },
+    enabled: isAccessToAnotherAgora.current === true,
   });
 
   const isSameAgora = (prevId: number, currentId: string | undefined) => {
@@ -95,46 +114,91 @@ export default function ChatPageLoadConfig({ children }: Props) {
     if (
       typeof window !== 'undefined' &&
       !isNull(session) &&
-      !hasMutated.current
+      !hasMutated.current &&
+      !isNull(selectedAgora.status)
     ) {
       const entries = performance.getEntriesByType(
         'navigation',
       )[0] as PerformanceNavigationTiming;
+      const sessionNavigatorPrevious = sessionStorage.getItem(
+        STORAGE_PREVIOUSE_URK_KEY,
+      );
 
-      if (entries?.type === 'reload') {
-        // 입장하기 api 호출
+      const previousUrl = `${window.location.origin}${sessionNavigatorPrevious ?? ''}`;
+
+      // 같은 채팅방일 때 (RELOAD)
+      // 기존 아고라가 CLOSED라면 종료된 아고라 입장하기 API 호출 (X -> get 요청임)
+      if (entries?.type === 'reload' && previousUrl === window.location.href) {
         hasMutated.current = true;
-        mutation.mutate();
-      }
-
-      if (entries?.type === 'navigate' && isNull(agoraTitle)) {
-        // 채팅방 입장하기 페이지 띄우기
+        // 기존 아고라가 ACTIVE라면 재입장 API 호출
+        if (
+          selectedAgora.status === 'QUEUED' ||
+          selectedAgora.status === 'RUNNING'
+        ) {
+          activeAgoraEnterMutation.mutate();
+        }
+      } else if (entries?.type === 'navigate' && isNull(selectedAgora.title)) {
+        // 외부에서 채팅방 접근시 채팅방 입장하기 페이지 띄우기
         window.location.replace(`/flow/enter-agora/${agoraId}`);
       } else if (
         entries?.type === 'navigate' &&
-        !isSameAgora(prevAgoraId, agoraId)
+        !isSameAgora(selectedAgora.id, agoraId)
       ) {
-        // 채팅방에서 다른 채팅방으로 이동, storage 데이터 초기화 후 입장하기 페이지 띄우기
-        agoraInfoReset();
+        // 채팅방에서 다른 채팅방으로 이동 시, 넘어간 채팅방의 유효성(CLOSED인지, ACTIVE인지, 없는지)을 먼저 검사해야함
+        // storage 데이터 초기화 후 입장하기 페이지 띄우기
+        isAccessToAnotherAgora.current = true;
         userProfilReset();
-        selectedAgoraInfoReset();
-
-        useAgora.persist.rehydrate();
-        useEnter.persist.rehydrate();
-
-        window.location.replace(`/flow/enter-agora/${agoraId}`);
       }
     }
   }, [session]);
 
-  if (
-    isNull(session) ||
-    isNull(agoraTitle) ||
-    !isSameAgora(prevAgoraId, agoraId) ||
-    mutation.isPending
-  ) {
+  useEffect(() => {
+    if (!isNull(agoraInfo)) {
+      // CLOSED AGORA일 때, 종료된 아고라 showToast 띄우기
+      if (agoraInfo.status === 'CLOSED') {
+        setSelectedAgora({
+          id: Number(agoraId),
+          thumbnail: '',
+          title: agoraInfo.title,
+          status: agoraInfo.status,
+          agoraColor: COLOR[0].value,
+        });
+        setEnterAgora({
+          ...selectedAgora,
+          id: Number(agoraId),
+          thumbnail: '',
+          title: agoraInfo.title,
+          status: agoraInfo.status,
+          userId: enterAgora.userId,
+          role: AGORA_POSITION.OBSERVER,
+          isCreator: false,
+        });
+
+        useAgora.persist.rehydrate();
+        useEnter.persist.rehydrate();
+      }
+      // ACTIVE AGORA일 때, /flow 입장하기 모달 출력
+      if (agoraInfo.status === 'QUEUED' || agoraInfo.status === 'RUNNING') {
+        agoraInfoReset();
+        selectedAgoraInfoReset();
+
+        window.location.replace(`/flow/enter-agora/${agoraId}`);
+      }
+    }
+  }, [agoraInfo]);
+
+  const isLoadingInActiveAgora =
+    (selectedAgora.status === 'QUEUED' || selectedAgora.status === 'RUNNING') &&
+    activeAgoraEnterMutation.isPending;
+
+  const isLoadingInClosedAgora =
+    selectedAgora.status === 'CLOSED' && LoadingGetBasicFacts;
+
+  if (isNull(session) || isLoadingInActiveAgora || isLoadingInClosedAgora) {
     return <ChatPageLoading />;
   }
 
-  return children;
+  if (!isNull(enterAgora.title)) {
+    return children;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import ServiceWorkerRegistration from './config/ServiceWorkerRegistration';
 import ToasterContainer from './config/ToasterContainer';
 import SetTheme from './_components/utils/SetTheme';
 import AuthSession from './_components/utils/AuthSession';
+import SuspensePreviousPageComponent from './_components/utils/SessionNavigationObserver';
 
 export const viewport: Viewport = {
   themeColor: '#3A3A3B',
@@ -63,6 +64,7 @@ export default async function RootLayout({
           <SetTheme theme={theme || THEME.LIGHT} />
           <MSWComponent />
           <ServiceWorkerRegistration />
+          <SuspensePreviousPageComponent />
           <RQProvider>
             {children}
             <ToasterContainer />

--- a/src/app/model/Agora.ts
+++ b/src/app/model/Agora.ts
@@ -25,10 +25,15 @@ export interface ClosedAgora {
   consCount: number;
   totalMember: number;
   createdAt: string;
-  status: string;
+  status: Status | '';
 }
 
 export type AgoraData = Agora | ClosedAgora;
+
+export interface AgoraBasicFacts {
+  title: string;
+  status: Status;
+}
 
 export interface AgoraUserProfileType {
   id: number;

--- a/src/constants/segmentKey.ts
+++ b/src/constants/segmentKey.ts
@@ -5,7 +5,7 @@ const userInfoSegmentKey = '/user-info';
 const uploadImageSegmentKey = '/upload-image';
 
 const STORAGE_CURRENT_URL_KEY = 'athens-cur';
-const STORAGE_PREVIOUSE_URK_KEY = 'athens-previous';
+const STORAGE_PREVIOUSE_URL_KEY = 'athens-previous';
 
 type HomeSegmentKeyType = '/home';
 type CreateAgoraSegmentKeyType = '/create-agora';
@@ -22,7 +22,7 @@ export type SegmentKeyType =
 
 export {
   STORAGE_CURRENT_URL_KEY,
-  STORAGE_PREVIOUSE_URK_KEY,
+  STORAGE_PREVIOUSE_URL_KEY,
   homeSegmentKey,
   createAgoraSegmentKey,
   enterAgoraSegmentKey,

--- a/src/constants/segmentKey.ts
+++ b/src/constants/segmentKey.ts
@@ -4,6 +4,9 @@ const enterAgoraSegmentKey = '/enter-agora';
 const userInfoSegmentKey = '/user-info';
 const uploadImageSegmentKey = '/upload-image';
 
+const STORAGE_CURRENT_URL_KEY = 'athens-cur';
+const STORAGE_PREVIOUSE_URK_KEY = 'athens-previous';
+
 type HomeSegmentKeyType = '/home';
 type CreateAgoraSegmentKeyType = '/create-agora';
 type EnterAgoraSegmentKeyType = '/enter-agora';
@@ -18,6 +21,8 @@ export type SegmentKeyType =
   | UploadImageSegmentKeyType;
 
 export {
+  STORAGE_CURRENT_URL_KEY,
+  STORAGE_PREVIOUSE_URK_KEY,
   homeSegmentKey,
   createAgoraSegmentKey,
   enterAgoraSegmentKey,

--- a/src/hooks/useApiError.ts
+++ b/src/hooks/useApiError.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import showToast from '@/utils/showToast';
-import { signOut } from 'next-auth/react';
+import { getSession, signOut } from 'next-auth/react';
 import { useCallback } from 'react';
 import {
   AUTHORIZATION_FAIL,
@@ -27,7 +27,8 @@ const useApiError = () => {
       retryMutation?: UseMutateFunction<any, Error, void, unknown>,
       queryKey?: QueryKey,
     ) => {
-      const reissueResponse = await callReissueFn();
+      const session = await getSession();
+      const reissueResponse = await callReissueFn(session);
 
       if (reissueResponse === AUTHORIZATION_FAIL) {
         showToast(

--- a/src/hooks/usePreviousPage.ts
+++ b/src/hooks/usePreviousPage.ts
@@ -2,7 +2,7 @@
 
 import {
   STORAGE_CURRENT_URL_KEY,
-  STORAGE_PREVIOUSE_URK_KEY,
+  STORAGE_PREVIOUSE_URL_KEY,
 } from '@/constants/segmentKey';
 import isNull from '@/utils/validation/validateIsNull';
 import { usePathname, useSearchParams } from 'next/navigation';
@@ -19,7 +19,7 @@ export default function usePreviousPage() {
     const previousUrl = storage.getItem(STORAGE_CURRENT_URL_KEY);
 
     if (!isNull(previousUrl)) {
-      storage.setItem(STORAGE_PREVIOUSE_URK_KEY, previousUrl);
+      storage.setItem(STORAGE_PREVIOUSE_URL_KEY, previousUrl);
     }
 
     storage.setItem(STORAGE_CURRENT_URL_KEY, currentUrl);

--- a/src/hooks/usePreviousPage.ts
+++ b/src/hooks/usePreviousPage.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import {
+  STORAGE_CURRENT_URL_KEY,
+  STORAGE_PREVIOUSE_URK_KEY,
+} from '@/constants/segmentKey';
+import isNull from '@/utils/validation/validateIsNull';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function usePreviousPage() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const storage = sessionStorage;
+    const currentUrl =
+      pathname + (searchParams.toString() ? `?${searchParams.toString()}` : '');
+    const previousUrl = storage.getItem(STORAGE_CURRENT_URL_KEY);
+
+    if (!isNull(previousUrl)) {
+      storage.setItem(STORAGE_PREVIOUSE_URK_KEY, previousUrl);
+    }
+
+    storage.setItem(STORAGE_CURRENT_URL_KEY, currentUrl);
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/src/hooks/useUnloadDisconnectSocket.tsx
+++ b/src/hooks/useUnloadDisconnectSocket.tsx
@@ -1,14 +1,16 @@
 'use client';
 
+import { Status } from '@/app/model/Agora';
 import { useWebSocketClient } from '@/store/webSocket';
 import { useCallback, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
 type Props = {
   mutation?: () => void;
+  agoraStatus: Status | '';
 };
 
-export function useUnloadDisconnectSocket({ mutation }: Props) {
+export function useUnloadDisconnectSocket({ mutation, agoraStatus }: Props) {
   const { webSocketClient } = useWebSocketClient(
     useShallow((state) => ({
       webSocketClient: state.webSocketClient,
@@ -18,7 +20,9 @@ export function useUnloadDisconnectSocket({ mutation }: Props) {
 
   const handleUnload = useCallback(() => {
     webSocketClient?.deactivate();
-    mutation?.();
+    if (agoraStatus !== 'CLOSED') {
+      mutation?.();
+    }
   }, [webSocketClient, mutation]);
 
   const handleBeforeUnload = useCallback((e: BeforeUnloadEvent) => {

--- a/src/hooks/useUnloadDisconnectSocket.tsx
+++ b/src/hooks/useUnloadDisconnectSocket.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Status } from '@/app/model/Agora';
+import { AGORA_STATUS } from '@/constants/agora';
 import { useWebSocketClient } from '@/store/webSocket';
 import { useCallback, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
@@ -20,7 +21,7 @@ export function useUnloadDisconnectSocket({ mutation, agoraStatus }: Props) {
 
   const handleUnload = useCallback(() => {
     webSocketClient?.deactivate();
-    if (agoraStatus !== 'CLOSED') {
+    if (agoraStatus !== AGORA_STATUS.CLOSED) {
       mutation?.();
     }
   }, [webSocketClient, mutation]);

--- a/src/hooks/useUpdateSession.ts
+++ b/src/hooks/useUpdateSession.ts
@@ -6,12 +6,13 @@ import {
 } from '@/constants/authErrorMessage';
 import { getReissuanceToken } from '@/lib/getReissuanceToken';
 import isNull from '@/utils/validation/validateIsNull';
+import { Session } from 'next-auth';
 import { useSession } from 'next-auth/react';
 
 const useUpdateSession = () => {
-  const { data: session, update } = useSession();
+  const { update } = useSession();
 
-  const callReissueFn = async () => {
+  const callReissueFn = async (session: Session | null) => {
     if (isNull(session) || isNull(session?.user)) {
       return AUTHORIZATION_FAIL;
     }

--- a/src/store/agora.ts
+++ b/src/store/agora.ts
@@ -1,3 +1,4 @@
+import { Status } from '@/app/model/Agora';
 import { COLOR } from '@/constants/consts';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
@@ -6,7 +7,7 @@ type Agora = {
   id: number;
   thumbnail: string;
   title: string;
-  status: string;
+  status: Status | '';
   agoraColor: string;
 };
 
@@ -15,7 +16,7 @@ type EnterAgora = {
   userId?: number;
   thumbnail: string;
   title: string;
-  status: string;
+  status: Status | '';
   role: string;
   isCreator: boolean;
   agoraColor: string;


### PR DESCRIPTION
### 🔗 Linked Issue

### 🛠 개발 기능

- 채팅방에서 다른 채팅방으로 넘어갈 때(navigate)
  - ACTIVE AGORA일 땐 `/flow` 입장하기 모달 출력
  - CLOSED AGORA일 땐 종료된 아고라라는 `showToast` 띄우기
- 같은 채팅방일 때(reload)
  - 기존 아고라가 ACTIVE라면 재입장 API 호출
- redirect는 상대 경로가 아닌 절대 경로를 사용해야 하므로 env 환경 파일에서 불러온 origin 추가
- 종료된 아고라에서 뒤로가 홈으로 이동시 다시 채팅방으로 이동하면서 에러가 발생하는 문제 수정

### 🧩 해결 방법

- reload 감지시 라우터 이동에서 서버로부터 새로운 데이터를 불러올 때도 reload로 감지하는 문제로 인해 세션 스토리지에 이전/현재 URL을 저장하여 reload 감지하도록 조건문 추가
- 종료된 아고라에서 새로고침시 unload에서 아고라 전역 상태 초기화되지 않도록 하여 기존 데이터 유지하도록 수정
- 종료된 아고라 입장 API 호출 조건을 전역 상태를 기반으로 했던 것을 버튼 클릭을 감지하여 호출하도록 수정

### 🔍 리뷰 포인트

- 

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
