### PR TITLE
QA에서 발견된 버그 수정사항 적용

### DIFF
--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -454,17 +454,25 @@ export default function Header() {
 
   // 브라우저 뒤로가기 버튼 클릭 시 페이지 이탈 방지 모달 띄우기
   useEffect(() => {
+    const isChatModalPath = (url: string, pathname: string) => {
+      if (
+        url === `${pathname}/flow/social-share` ||
+        url === `${pathname}/flow/end-agora` ||
+        url === `${pathname}/flow/result-agora`
+      ) {
+        return true;
+      }
+      return false;
+    };
+
     const handlePopState = (event: PopStateEvent) => {
       event.preventDefault();
       const { pathname } = window.location;
       window.history.pushState(null, '', pathname); // 뒤로가기 무효화
 
-      const previousPath = sessionStorage.getItem(STORAGE_PREVIOUSE_URL_KEY);
-      if (
-        previousPath === `${pathname}/flow/social-share` ||
-        previousPath === `${pathname}/flow/end-agora` ||
-        previousPath === `${pathname}/flow/result-agora`
-      ) {
+      const previousPath =
+        sessionStorage.getItem(STORAGE_PREVIOUSE_URL_KEY) ?? '';
+      if (isChatModalPath(previousPath, pathname)) {
         sessionStorage.setItem(STORAGE_PREVIOUSE_URL_KEY, pathname);
         return;
       }

--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -20,7 +20,10 @@ import {
   getAgoraUserListQueryKey,
   getChatMessagesQueryKey,
 } from '@/constants/queryKey';
-import { homeSegmentKey } from '@/constants/segmentKey';
+import {
+  STORAGE_PREVIOUSE_URL_KEY,
+  homeSegmentKey,
+} from '@/constants/segmentKey';
 import { AGORA_POSITION, AGORA_STATUS } from '@/constants/agora';
 import { swalBackButtonAlert } from '@/utils/swalAlert';
 import useApiError from '@/hooks/useApiError';
@@ -257,20 +260,6 @@ export default function Header() {
       newMessages,
     );
     setGoDown(true);
-    // console.log('newMessages', newMessages);
-
-    // let accessStatus = null;
-
-    // if (userDisconnectTime === null) {
-    //   accessStatus = 'enter';
-    // } else if (userDisconnectTime.length > 0) {
-    //   accessStatus = 'exit';
-    // }
-
-    // queryClient.setQueryData(getChatMessagesQueryKey(enterAgoraId), {
-    //   status: accessStatus,
-    //   username,
-    // });
   };
 
   const updateParticipantList = (
@@ -346,8 +335,6 @@ export default function Header() {
     },
     [setSocketError, socketError],
   );
-
-  // 최초 렌더링 시 실행
 
   const disconnect = useCallback(async () => {
     if (!isNull(webSocketClient) && webSocketClientConnected) {
@@ -479,7 +466,19 @@ export default function Header() {
   useEffect(() => {
     const handlePopState = (event: PopStateEvent) => {
       event.preventDefault();
-      window.history.pushState(null, '', window.location.pathname); // 뒤로가기 무효화
+      const { pathname } = window.location;
+      window.history.pushState(null, '', pathname); // 뒤로가기 무효화
+
+      const previousPath = sessionStorage.getItem(STORAGE_PREVIOUSE_URL_KEY);
+      if (
+        previousPath === `${pathname}/flow/social-share` ||
+        previousPath === `${pathname}/flow/end-agora` ||
+        previousPath === `${pathname}/flow/result-agora`
+      ) {
+        sessionStorage.setItem(STORAGE_PREVIOUSE_URL_KEY, pathname);
+        return;
+      }
+
       handleBack();
     };
 

--- a/src/app/(chat)/_lib/getAgoraUsers.ts
+++ b/src/app/(chat)/_lib/getAgoraUsers.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { AgoraUserProfileType } from '@/app/model/Agora';
+import { AgoraSideBarDataType } from '@/app/model/Agora';
 import { QueryFunction } from '@tanstack/react-query';
 import { getAgoraUserListQueryKey as getAgoraUserListTags } from '@/constants/queryKey';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
@@ -13,7 +13,7 @@ import {
 import isNull from '@/utils/validation/validateIsNull';
 
 export const getAgoraUsers: QueryFunction<
-  AgoraUserProfileType[],
+  AgoraSideBarDataType,
   [string, string, string]
 > = async ({ queryKey }) => {
   const [_1, _2, agoraId] = queryKey;
@@ -52,7 +52,7 @@ export const getAgoraUsers: QueryFunction<
     throw new Error(AGORA_USER.FAILED_TO_GET_AGORA_USER);
   }
 
-  const result = res.response.participants;
+  const result = res.response;
 
   return result;
 };

--- a/src/app/(main)/_lib/postEnterClosedAgora.ts
+++ b/src/app/(main)/_lib/postEnterClosedAgora.ts
@@ -7,16 +7,16 @@ import {
 } from '@/constants/responseErrorMessage';
 import isNull from '@/utils/validation/validateIsNull';
 
-export const getEnterClosedAgoraStatus = async (agoraId: number) => {
+export const postEnterClosedAgora = async (agoraId: number) => {
   const session = await getSession();
   if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 
   const res = await callFetchWrapper(
-    `/api/v1/auth/agoras/${agoraId}/participants`,
+    `/api/v1/auth/agoras/${agoraId}/closed/participants`,
     {
-      method: 'get',
+      method: 'post',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${session.user?.accessToken}`,

--- a/src/app/model/Agora.ts
+++ b/src/app/model/Agora.ts
@@ -42,6 +42,12 @@ export interface AgoraUserProfileType {
   type: ParticipationPosition;
 }
 
+export interface AgoraSideBarDataType {
+  agoraId: number;
+  imageUrl: string;
+  participants: AgoraUserProfileType[];
+}
+
 export type ParticipantCountAction = 'DECREASE' | 'INCREASE';
 
 export interface SearchParams {


### PR DESCRIPTION
### 🔗 Linked Issue

### 🛠 개발 기능

- 채팅방에서 라우터 이동시 페이지 이탈 방지 모달이 뜨는 문제 수정
- 종료된 아고라 입장시 GET 요청 보내던 API POST로 수정
- 채팅방 이미지 수정되었을 때, 채팅방 내 유저들에게 이미지 수정사항이 적용되지 않는 문제 수정

### 🧩 해결 방법

- 세션 쿠키에 저장해두었던 '현재 URL', '이전 URL'을 활용해서 페이지 이탈 방지 모달이 뜨지 않도록 했습니다.
  - 채팅방에서 라우터로 인한 경로 변경시 현재 경로와 이전 경로를 채팅방 URL (/agoras/${agoraId})로 같게 하여 페이지 이동으로 감지하지 않도록 하였습니다.
- 종료된 아고라 입장 API가 GET에서 POST로 바뀌면서, useQuery로 관리해주던 데이터를 useMutation으로 수정해주었습니다.
- 사이드바 API 호출 시 유저 리스트만 응답받던 API에 thumbnail까지 추가하여 이미지가 수정되었을 시 적용될 수 있도록 하였습니다.

### 🔍 리뷰 포인트

- .

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
