### PR TITLE
강제 퇴장 동작 및 채팅 반응 로직 수정

### DIFF
--- a/src/app/(chat)/_components/molecules/AgoraUserList.tsx
+++ b/src/app/(chat)/_components/molecules/AgoraUserList.tsx
@@ -15,6 +15,7 @@ import { useRouter } from 'next/navigation';
 import { homeSegmentKey } from '@/constants/segmentKey';
 import useApiError from '@/hooks/useApiError';
 import { useKickedStore } from '@/store/kick';
+import showToast from '@/utils/showToast';
 import UserImage from '../../../_components/atoms/UserImage';
 import { postKickVote } from '../../_lib/postKickVote';
 import patchChatExit from '../../_lib/patchChatExit';
@@ -72,6 +73,14 @@ export default function AgoraUserList({
       agoraId,
     }: KickMutationProps) =>
       postKickVote(targetMemberId, currentMemberCount, agoraId),
+    onSuccess: (response) => {
+      if (response.success) {
+        showToast('강퇴 투표에 성공하였습니다.', 'success');
+        return;
+      }
+
+      showToast('강퇴 투표에 실패하였습니다', 'error');
+    },
   });
 
   const { setKicked } = useKickedStore(

--- a/src/app/(chat)/_components/molecules/AgoraUserList.tsx
+++ b/src/app/(chat)/_components/molecules/AgoraUserList.tsx
@@ -48,6 +48,9 @@ export default function AgoraUserList({
   subscribeCount,
   decrementSubscribeCount,
 }: Props) {
+  const router = useRouter();
+  const { handleError } = useApiError();
+
   const { participants } = useChatInfo(
     useShallow((state) => ({
       participants: state.participants,
@@ -82,6 +85,9 @@ export default function AgoraUserList({
 
       showToast('강퇴 투표에 실패하였습니다', 'error');
     },
+    onError: async (error, variables) => {
+      await handleError(error, () => kickVoteMutation.mutate(variables));
+    },
   });
 
   const { setKicked } = useKickedStore(
@@ -89,9 +95,6 @@ export default function AgoraUserList({
       setKicked: state.setKicked,
     })),
   );
-
-  const router = useRouter();
-  const { handleError } = useApiError();
 
   const handleKick = (
     targetMemberId: number,

--- a/src/app/(chat)/_components/molecules/AgoraUserList.tsx
+++ b/src/app/(chat)/_components/molecules/AgoraUserList.tsx
@@ -16,6 +16,7 @@ import { homeSegmentKey } from '@/constants/segmentKey';
 import useApiError from '@/hooks/useApiError';
 import { useKickedStore } from '@/store/kick';
 import showToast from '@/utils/showToast';
+import { useEnter } from '@/store/enter';
 import UserImage from '../../../_components/atoms/UserImage';
 import { postKickVote } from '../../_lib/postKickVote';
 import patchChatExit from '../../_lib/patchChatExit';
@@ -92,7 +93,16 @@ export default function AgoraUserList({
   const router = useRouter();
   const { handleError } = useApiError();
 
-  const handleKick = (targetMemberId: number, agoraId: number) => {
+  const handleKick = (
+    targetMemberId: number,
+    agoraId: number,
+    nickname: string,
+  ) => {
+    if (useEnter.getState().nickname === nickname) {
+      showToast('자신에게 투표할 수 없습니다.', 'error');
+      return;
+    }
+
     const currentMemberCount = participants.size;
 
     kickVoteMutation.mutate({ targetMemberId, currentMemberCount, agoraId });
@@ -194,8 +204,12 @@ export default function AgoraUserList({
                 </div>
                 <button
                   type="button"
-                  onClick={() => handleKick(user.id, enterAgora.id)}
-                  onKeyDown={() => handleKick(user.id, enterAgora.id)}
+                  onClick={() =>
+                    handleKick(user.id, enterAgora.id, user.nickname)
+                  }
+                  onKeyDown={() =>
+                    handleKick(user.id, enterAgora.id, user.nickname)
+                  }
                   className="w-70 h-24 text-xs bg-red-500 text-white rounded-md"
                 >
                   추방하기

--- a/src/app/(chat)/_components/molecules/Message.tsx
+++ b/src/app/(chat)/_components/molecules/Message.tsx
@@ -79,10 +79,17 @@ function MessageItem({
   const isSameTime = nextMessage && currentMessageTime === nextMessageTime;
   const shouldShowTime = !isNextSameUser || !isSameTime;
 
-  queryClient.setQueryData(
+  const beforeReactions = queryClient.getQueryData(
     getUserReactionQueryKey(agoraId, message.chatId),
-    message.reactionCount,
   );
+
+  if (isNull(beforeReactions)) {
+    // 캐시에 저장된 값이 없을 때만, 초기 데이터를 set
+    queryClient.setQueryData(
+      getUserReactionQueryKey(agoraId, message.chatId),
+      message.reactionCount,
+    );
+  }
 
   return isMyMessage ? (
     <MyMessage
@@ -157,6 +164,8 @@ export default function Message() {
   const handleWebSocketReaction = useCallback(
     (response: any) => {
       if (response.type === 'REACTION') {
+        console.log('reaction', response);
+        console.log(agoraId, response.data.chatId);
         queryClient.setQueryData(
           getUserReactionQueryKey(agoraId, response.data.chatId),
           response.data.reactionCount,

--- a/src/app/(chat)/_lib/postKickVote.ts
+++ b/src/app/(chat)/_lib/postKickVote.ts
@@ -61,4 +61,6 @@ export const postKickVote = async (
 
     throw new Error(PATCH_USER_KICK_VOTE_ERROR_MESSAGE.FAILED_TO_KICK_VOTE);
   }
+
+  return res;
 };


### PR DESCRIPTION
### 🛠 개발 기능

- 강제퇴장 투표시 성공여부 Toast에 띄우는 기능 추가
- 강퇴 투표를 자신에게 할 수 없도록 수정
- 기존 채팅에 반응을 남겨도 제대로 표시되지 않던 문제 해결
### 🧩 해결 방법

- 채팅 반응 로직을 api를 통해 받아온 기존 반응을 기준으로 카운트 하도록 변경

### 🔍 리뷰 포인트

- 리뷰 시 어떤 부분에 집중해야 할지 명시해주세요.

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
