### PR TITLE
아고라 생성시 크롭 이미지 크기로 세션 용량 초과 문제 수정

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,3 @@
 yarnPath: .yarn/releases/yarn-4.1.1.cjs
 nodeLinker: pnp
-packageExtensions:
+packageExtensions: {}

--- a/src/app/(main)/_lib/postCreateAgora.ts
+++ b/src/app/(main)/_lib/postCreateAgora.ts
@@ -1,5 +1,4 @@
 import { AgoraConfig } from '@/app/model/Agora';
-import { base64ToFile } from '@/utils/base64ToFile';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import { AUTH_MESSAGE, SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
@@ -33,12 +32,24 @@ export const postCreateAgora = async (info: AgoraConfig) => {
   });
 
   // base64로 인코딩된 이미지를 디코딩하여 파일로 변환
-  const file = info.thumbnail
-    ? base64ToFile(info.thumbnail, `${info.title}.jpg`)
-    : '';
-
+  // const file = info.thumbnail
+  //   ? base64ToFile(info.thumbnail, `${info.title}.jpg`)
+  //   : '';
   formData.append('request', blob);
-  formData.append('file', file);
+
+  if (!isNull(info.thumbnail)) {
+    try {
+      const response = await fetch(info.thumbnail);
+      const blobData = await response.blob();
+      const file = new File([blobData], `${info.title}.jpg`, {
+        type: blobData.type || 'image/jpeg',
+      });
+
+      formData.append('file', file);
+    } catch (error) {
+      throw new Error('이미지 업로드 중 오류가 발생했습니다.');
+    }
+  }
 
   const session = await getSession();
   if (isNull(session)) {

--- a/src/app/(main)/create-agora/_component/CreateAgoraImageUpload.tsx
+++ b/src/app/(main)/create-agora/_component/CreateAgoraImageUpload.tsx
@@ -3,6 +3,7 @@
 import AgoraImageUpload from '@/app/_components/organisms/AgoraImageUpload';
 import { useCreateAgora } from '@/store/create';
 import { initialImage, useUploadImage } from '@/store/uploadImage';
+import { convertBase64ToBlobUrl } from '@/utils/convertBase64ToBlobUrl';
 import isNull from '@/utils/validation/validateIsNull';
 import React, { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
@@ -25,7 +26,7 @@ export default function CreateAgoraImageUpload() {
     if (isNull(cropedPreview.dataUrl)) {
       setThumbnail('');
     } else {
-      setThumbnail(cropedPreview.dataUrl);
+      setThumbnail(convertBase64ToBlobUrl(cropedPreview.dataUrl));
     }
   }, [cropedPreview.dataUrl, setThumbnail]);
 

--- a/src/app/_components/molecules/ImageCropper.tsx
+++ b/src/app/_components/molecules/ImageCropper.tsx
@@ -120,7 +120,7 @@ export default function ImageCropper() {
 
     try {
       await new Promise<void>((resolve) => {
-        setTimeout(() => {
+        setTimeout(async () => {
           if (
             isNull(imgRef.current) ||
             isNull(canvasRef.current) ||
@@ -129,7 +129,7 @@ export default function ImageCropper() {
             return;
           }
 
-          getCroppedImg(
+          const croppedImage = await getCroppedImg(
             imgRef.current,
             canvasRef.current,
             convertToPixelCrop(
@@ -137,12 +137,15 @@ export default function ImageCropper() {
               imgRef.current?.width,
               imgRef.current?.height,
             ),
+            'image/jpeg',
+            0.9, // 90% 품질의 JPEG로 변환
           );
 
-          const dataUrl = canvasRef.current.toDataURL();
           setCropedPreview({
-            dataUrl,
-            file: new File([dataUrl], 'image'),
+            dataUrl: croppedImage,
+            file: new File([croppedImage], 'image.jpeg', {
+              type: 'image/jpeg',
+            }),
           });
 
           resolve();

--- a/src/utils/convertBase64ToBlobUrl.ts
+++ b/src/utils/convertBase64ToBlobUrl.ts
@@ -1,0 +1,16 @@
+import isNull from './validation/validateIsNull';
+
+export const convertBase64ToBlobUrl = (base64: string) => {
+  const base64Data = base64.split(',')[1]?.replace(/[\s\n]/g, ''); // "data:image/jpeg;base64," 제거
+  if (isNull(base64Data)) {
+    return '';
+  }
+
+  const byteCharacters = atob(base64Data);
+  const byteNumbers = new Array(byteCharacters.length)
+    .fill(null)
+    .map((_, i) => byteCharacters.charCodeAt(i));
+  const byteArray = new Uint8Array(byteNumbers);
+  const blob = new Blob([byteArray], { type: 'image/jpeg' });
+  return URL.createObjectURL(blob);
+};

--- a/src/utils/getCroppedImg.ts
+++ b/src/utils/getCroppedImg.ts
@@ -1,46 +1,49 @@
 import { PixelCrop } from 'react-image-crop';
 
-const getCroppedImg = (
+const getCroppedImg = async (
   image: HTMLImageElement,
   originalCanvas: HTMLCanvasElement,
   crop: PixelCrop,
-) => {
-  const canvas = originalCanvas; // canvas의 복사본을 생성
+  format: 'image/png' | 'image/jpeg' = 'image/jpeg', // 기본값을 JPEG로 설정
+  quality: number = 0.9, // JPEG 품질 설정
+): Promise<string> => {
+  const canvas = originalCanvas;
   const ctx = canvas.getContext('2d');
 
   if (!ctx) {
     throw new Error('No 2d context');
   }
 
-  const pixelRatio = window.devicePixelRatio;
+  // const pixelRatio = 1; // 👉 필요 없으면 1로 고정
   const scaleX = image.naturalWidth / image.width;
   const scaleY = image.naturalHeight / image.height;
 
-  canvas.width = Math.floor(crop.width * scaleX * pixelRatio);
-  canvas.height = Math.floor(crop.height * scaleY * pixelRatio);
+  // 📌 크롭된 크기만큼만 canvas 크기를 설정 (해상도 증가 방지)
+  canvas.width = Math.floor(crop.width * scaleX);
+  canvas.height = Math.floor(crop.height * scaleY);
 
-  ctx.scale(pixelRatio, pixelRatio);
   ctx.imageSmoothingQuality = 'high';
   ctx.save();
 
   const cropX = crop.x * scaleX;
   const cropY = crop.y * scaleY;
 
-  // 5) Move the crop origin to the canvas origin (0,0)
-  ctx.translate(-cropX, -cropY);
+  // 📌 크롭된 영역만 캔버스에 그림
   ctx.drawImage(
     image,
+    cropX,
+    cropY,
+    crop.width * scaleX,
+    crop.height * scaleY, // 크롭된 부분만 가져오기
     0,
     0,
-    image.naturalWidth,
-    image.naturalHeight,
-    0,
-    0,
-    image.naturalWidth,
-    image.naturalHeight,
+    canvas.width,
+    canvas.height,
   );
 
   ctx.restore();
+
+  return canvas.toDataURL(format, quality);
 };
 
 export default getCroppedImg;


### PR DESCRIPTION
### 🔗 Linked Issue

### 🛠 개발 기능

- 크롭한 이미지 png에서 jpeg로 저장하도록 변경
- 아고라 생성 후 입장 모달 뜰 때 세션 쿠키에 데이터 url이 아닌 blob url로 저장하도록 수정

### 🧩 해결 방법

- 개발 기능에 작성된 방법으로 수정하였습니다.

### 🔍 리뷰 포인트

- 

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
