### PR TITLE
채팅방에서 강퇴된 인원이 이후 강퇴 투표의 과반수 계산에 포함되는 문제를 수정

### DIFF
--- a/src/app/(chat)/_components/molecules/AgoraUserList.tsx
+++ b/src/app/(chat)/_components/molecules/AgoraUserList.tsx
@@ -70,6 +70,12 @@ export default function AgoraUserList({
     })),
   );
 
+  const { removeParticipant } = useChatInfo(
+    useShallow((state) => ({
+      removeParticipant: state.removeParticipant,
+    })),
+  );
+
   const kickVoteMutation = useMutation({
     mutationFn: async ({
       targetMemberId,
@@ -130,13 +136,20 @@ export default function AgoraUserList({
   });
 
   const isKickVoteApproved = (response: KickVoteResponse) =>
-    response.type === 'KICK' &&
+    response.type === 'KICK';
+
+  const amIKicked = (response: KickVoteResponse) =>
     enterAgora.userId === response.kickVoteInfo.targetMemberId;
 
   const handleKickVoteResponse = useCallback(
     (response: KickVoteResponse) => {
       if (isKickVoteApproved(response)) {
-        handleApprovedKickVoteMutation.mutate();
+        if (amIKicked(response)) {
+          handleApprovedKickVoteMutation.mutate();
+          return;
+        }
+        // 내가 강퇴된 것이 아니라면, participants의 숫자를 조정
+        removeParticipant(response.kickVoteInfo.targetMemberId);
       }
     },
     [enterAgora.userId],

--- a/src/app/(chat)/_components/molecules/Message.tsx
+++ b/src/app/(chat)/_components/molecules/Message.tsx
@@ -164,8 +164,6 @@ export default function Message() {
   const handleWebSocketReaction = useCallback(
     (response: any) => {
       if (response.type === 'REACTION') {
-        console.log('reaction', response);
-        console.log(agoraId, response.data.chatId);
         queryClient.setQueryData(
           getUserReactionQueryKey(agoraId, response.data.chatId),
           response.data.reactionCount,

--- a/src/app/(chat)/_components/organisms/AgoraUserSuspense.tsx
+++ b/src/app/(chat)/_components/organisms/AgoraUserSuspense.tsx
@@ -30,10 +30,11 @@ function FallbackComponent(props: FallbackProps) {
 export default function AgoraUserSuspense({ agoraId }: Props) {
   const { enterAgora, selectedAgora, setSelectedAgora, setEnterAgora } =
     useAgora();
-  const { end, addParticipant } = useChatInfo(
+  const { end, addParticipant, resetParticipants } = useChatInfo(
     useShallow((state) => ({
       end: state.end,
       addParticipant: state.addParticipant,
+      resetParticipants: state.resetParticipants,
     })),
   );
 
@@ -72,6 +73,7 @@ export default function AgoraUserSuspense({ agoraId }: Props) {
     if (isNull(data)) return;
 
     updateAgoraThumnail(data.imageUrl);
+    resetParticipants();
 
     data.participants.forEach((user) => {
       const { id, nickname } = user;

--- a/src/app/_components/utils/SetChatInfoReset.tsx
+++ b/src/app/_components/utils/SetChatInfoReset.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import isNull from '@/utils/validation/validateIsNull';
 import { usePathname } from 'next/navigation';
+import { useChatInfo } from '@/store/chatInfo';
 
 export default function SetChatInfoReset() {
   const {
@@ -19,6 +20,13 @@ export default function SetChatInfoReset() {
       reset: state.reset,
     })),
   );
+
+  const { resetParticipants } = useChatInfo(
+    useShallow((state) => ({
+      resetParticipants: state.resetParticipants,
+    })),
+  );
+
   const { reset: userProfileReset } = useEnter();
   const pathname = usePathname();
 
@@ -34,6 +42,7 @@ export default function SetChatInfoReset() {
         agoraInfoReset();
         userProfileReset();
         selectedAgoraInfoReset();
+        resetParticipants();
 
         useAgora.persist.rehydrate();
         useEnter.persist.rehydrate();

--- a/src/utils/swalAlert.ts
+++ b/src/utils/swalAlert.ts
@@ -98,7 +98,7 @@ let timerInterval: ReturnType<typeof setInterval>;
 export const swalDeleteAccountSuccessAlert = async () => {
   return swalDeleteAccountSuccessAlertClass.fire({
     width: '300px',
-    title: '계정이 삭제 되었습니다',
+    title: '계정을 삭제 하는 중입니다..',
     html: '<b></b> 초 뒤에 로그인 화면으로 이동합니다.',
     timer: 5000,
     timerProgressBar: true,


### PR DESCRIPTION
### 🛠 개발 기능

- 채팅방에서 강퇴된 인원이 이후 강퇴 투표의 과반수 계산에 포함되는 문제를 수정
- 계정 삭제시 progress bar 안내 메시지 변경
- 몇 몇 리팩토링

### 🧩 해결 방법

- 현재 아고라에 참여하고 있는 유저를 {id: 닉네임} 형태로 participants(Map 객체)에 저장하고 쓰고 있는데, 다른 유저가 강퇴 되었을 때 해당 인원을 participants에서 제거해줌으로써, 총 인원수를 관리하도록 변경했습니다.

### 🔍 리뷰 포인트

- 리뷰 시 어떤 부분에 집중해야 할지 명시해주세요.

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
