### PR TITLE
이미지 없이 채팅방 생성시 파일 형태로 전달하지 않으면 발생하는 에러 수정

### DIFF
--- a/src/app/(main)/_lib/postCreateAgora.ts
+++ b/src/app/(main)/_lib/postCreateAgora.ts
@@ -51,7 +51,7 @@ export const postCreateAgora = async (info: AgoraConfig) => {
       throw new Error('이미지 업로드 중 오류가 발생했습니다.');
     }
   } else if (isNull(info.thumbnail)) {
-    formData.append('file', info.thumbnail);
+    formData.append('file', new File([''], 'no-img'));
   }
 
   const session = await getSession();


### PR DESCRIPTION
### 🔗 Linked Issue

### 🛠 개발 기능

- 기존에 이미지 없이 채팅방 생성할 때 file을 빈 문자열('')로 넘겨주면 되었지만, 서버 코드 수정으로 인해 File 객체로 넘겨줘야 하는 문제로 인해 빈 문자열을 File 객체로 전달하도록 수정

### 🧩 해결 방법

- 개발 기능과 동일합니다.

### 🔍 리뷰 포인트

- 

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
