### PR TITLE
채팅방 뒤로가기 문제 및 서버 응답 이미지 프로퍼티 key 수정

### DIFF
--- a/src/app/(chat)/_components/molecules/ModifyAgoraImage.tsx
+++ b/src/app/(chat)/_components/molecules/ModifyAgoraImage.tsx
@@ -52,7 +52,7 @@ export default function ModifyAgoraImage() {
     <div className="relative">
       <AgoraImageUpload
         page={`/agoras/${enterAgora.id}`}
-        image={enterAgora.thumbnail}
+        image={enterAgora.thumbnail ?? ''}
         color={enterAgora.agoraColor}
       />
       {/* TODO: 이미지 수정 했을 때만 저장 버튼 출력하도록 수정 */}

--- a/src/app/(chat)/_components/organisms/AgoraUserSuspense.tsx
+++ b/src/app/(chat)/_components/organisms/AgoraUserSuspense.tsx
@@ -72,7 +72,7 @@ export default function AgoraUserSuspense({ agoraId }: Props) {
   useEffect(() => {
     if (isNull(data)) return;
 
-    updateAgoraThumnail(data.agoraThumbnailUrl);
+    updateAgoraThumnail(data.agoraThumbnailUrl ?? '');
     resetParticipants();
 
     data.participants.forEach((user) => {

--- a/src/app/(chat)/_components/organisms/AgoraUserSuspense.tsx
+++ b/src/app/(chat)/_components/organisms/AgoraUserSuspense.tsx
@@ -72,7 +72,7 @@ export default function AgoraUserSuspense({ agoraId }: Props) {
   useEffect(() => {
     if (isNull(data)) return;
 
-    updateAgoraThumnail(data.imageUrl);
+    updateAgoraThumnail(data.agoraThumbnailUrl);
     resetParticipants();
 
     data.participants.forEach((user) => {

--- a/src/app/(chat)/_components/templates/AgoraSideBar.tsx
+++ b/src/app/(chat)/_components/templates/AgoraSideBar.tsx
@@ -112,7 +112,7 @@ export default function AgoraSideBar() {
                     {isValidImgUrl(enterAgora.thumbnail) ? (
                       <div className="relative w-60 h-60">
                         <Image
-                          src={enterAgora.thumbnail}
+                          src={enterAgora.thumbnail ?? ''}
                           alt="아고라 프로필"
                           layout="fill"
                           objectFit="cover"

--- a/src/app/(chat)/utils/resetStateOnChatExit.ts
+++ b/src/app/(chat)/utils/resetStateOnChatExit.ts
@@ -6,7 +6,7 @@ import { useUploadImage } from '@/store/uploadImage';
 
 export const resetStateOnChatExit = () => {
   useEnter.getState().reset();
-  useAgora.getState().reset();
+  // useAgora.getState().reset();
   useAgora.getState().enterAgoraReset();
   useUploadImage.getState().resetUploadImageState();
   useChatInfo.getState().reset();

--- a/src/app/config/ChatPageLoadConfig.tsx
+++ b/src/app/config/ChatPageLoadConfig.tsx
@@ -11,6 +11,7 @@ import { AGORA_POSITION, AGORA_STATUS } from '@/constants/agora';
 import showToast from '@/utils/showToast';
 import useApiError from '@/hooks/useApiError';
 import {
+  STORAGE_CURRENT_URL_KEY,
   STORAGE_PREVIOUSE_URL_KEY,
   homeSegmentKey,
 } from '@/constants/segmentKey';
@@ -90,7 +91,13 @@ export default function ChatPageLoadConfig({ children }: Props) {
     },
   });
 
-  const isRedirect = isNull(selectedAgora.title) && isNull(enterAgora.title);
+  const sessionNavigatorCurrent = sessionStorage.getItem(
+    STORAGE_CURRENT_URL_KEY,
+  );
+  const isRedirect =
+    !sessionNavigatorCurrent?.startsWith(homeSegmentKey) &&
+    isNull(selectedAgora.title) &&
+    isNull(enterAgora.title);
 
   const {
     data: agoraInfo,
@@ -154,6 +161,7 @@ export default function ChatPageLoadConfig({ children }: Props) {
         // storage 데이터 초기화 후 입장하기 페이지 띄우기
         isAccessToAnotherAgora.current = true;
         userProfilReset();
+        window.location.replace(`/flow/enter-agora/${agoraId}`);
       }
     }
   }, [session]);

--- a/src/app/config/ChatPageLoadConfig.tsx
+++ b/src/app/config/ChatPageLoadConfig.tsx
@@ -11,7 +11,6 @@ import { AGORA_POSITION, AGORA_STATUS } from '@/constants/agora';
 import showToast from '@/utils/showToast';
 import useApiError from '@/hooks/useApiError';
 import {
-  STORAGE_CURRENT_URL_KEY,
   STORAGE_PREVIOUSE_URL_KEY,
   homeSegmentKey,
 } from '@/constants/segmentKey';
@@ -91,13 +90,7 @@ export default function ChatPageLoadConfig({ children }: Props) {
     },
   });
 
-  const sessionNavigatorCurrent = sessionStorage.getItem(
-    STORAGE_CURRENT_URL_KEY,
-  );
-  const isRedirect =
-    !sessionNavigatorCurrent?.startsWith(homeSegmentKey) &&
-    isNull(selectedAgora.title) &&
-    isNull(enterAgora.title);
+  const isRedirect = isNull(selectedAgora.title) && isNull(enterAgora.title);
 
   const {
     data: agoraInfo,

--- a/src/app/model/Agora.ts
+++ b/src/app/model/Agora.ts
@@ -44,7 +44,7 @@ export interface AgoraUserProfileType {
 
 export interface AgoraSideBarDataType {
   agoraId: number;
-  imageUrl: string;
+  agoraThumbnailUrl: string;
   participants: AgoraUserProfileType[];
 }
 

--- a/src/app/model/Agora.ts
+++ b/src/app/model/Agora.ts
@@ -44,7 +44,7 @@ export interface AgoraUserProfileType {
 
 export interface AgoraSideBarDataType {
   agoraId: number;
-  agoraThumbnailUrl: string;
+  agoraThumbnailUrl: string | null;
   participants: AgoraUserProfileType[];
 }
 

--- a/src/store/agora.ts
+++ b/src/store/agora.ts
@@ -5,7 +5,7 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 
 type Agora = {
   id: number;
-  thumbnail: string;
+  thumbnail: string | null;
   title: string;
   status: Status | '';
   agoraColor: string;
@@ -14,7 +14,7 @@ type Agora = {
 type EnterAgora = {
   id: number;
   userId?: number;
-  thumbnail: string;
+  thumbnail: string | null;
   title: string;
   status: Status | '';
   role: string;

--- a/src/utils/validation/validateImage.ts
+++ b/src/utils/validation/validateImage.ts
@@ -1,4 +1,4 @@
-export const isValidImgUrl = (url: string) => {
+export const isValidImgUrl = (url: string | null) => {
   const regex =
     /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%/.\w-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[\w]*))?)/;
 


### PR DESCRIPTION
### 🔗 Linked Issue

### 🛠 개발 기능

- 채팅방 뒤로가기 시 가끔 입장하기 모달이 뜨는 문제
- 채팅방 사이드가 열 때 채팅방 이미지가 안보이는 문제

### 🧩 해결 방법

- 뒤로가기 시 호출되는 reset 모음 함수에서 selectedAgora reset을 제외하여 호출하도록 수정
  - 남아있는 채팅방 정보가 없어서 상위 컴포넌트인 `ChatPageLoadConfig` 파일에서 다른 페이지에서의 접근으로 인식해 입장 모달을 띄운 것입니다.
  - 그래서 selectedAgora 정보를 남겨주도록 하였습니다.
  - selectedAgora 정보를 가지고 채팅방 직접 접근시의 유저 시나리오는 이전에 고려해두었습니다.
- 채팅방에서 아고라 이미지가 가끔 보이지 않는 문제는, 서버로부터 응답받은 이미지 프로퍼티가 클라이언트에 저장된 타입 정보와 일치하지 않아 발생한 것입니다.
  이를 같게 해주었습니다.

### 🔍 리뷰 포인트

- 리뷰 시 어떤 부분에 집중해야 할지 명시해주세요.

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
