### PR TITLE
채팅방 유저 강퇴시 다른 사용자들에게 강퇴 메시지 가도록 구현

### DIFF
--- a/src/app/(chat)/_components/atoms/UserAccessNotification.tsx
+++ b/src/app/(chat)/_components/atoms/UserAccessNotification.tsx
@@ -1,9 +1,10 @@
+import { AccessStatus } from '@/app/model/Message';
 import React from 'react';
 
 type Props = {
   className?: string;
   nickname: string;
-  access: string;
+  access: AccessStatus;
 };
 
 export default function UserAccessNotification({
@@ -11,7 +12,15 @@ export default function UserAccessNotification({
   nickname,
   access,
 }: Props) {
-  const accessString = access === 'enter' ? '입장했습니다.' : '나갔습니다.';
+  const getAccessString = () => {
+    let baseStr = `${nickname} 님이`;
+
+    if (access === 'enter') baseStr += '입장했습니다.';
+    else if (access === 'kicked') baseStr += '강퇴 투표로 퇴장 처리되었습니다.';
+    else if (access === 'exit') baseStr += '나갔습니다.';
+    return baseStr;
+  };
+
   return (
     <div className={className}>
       <div className="w-full flex flex-col justify-center items-center">
@@ -19,7 +28,7 @@ export default function UserAccessNotification({
           aria-live="polite"
           className="rounded-3xl p-8 px-16 text-center foldable:text-xs text-xxs text-black bg-athens-gray dark:bg-dark-light-200 dark:text-dark-line w-fit  break-keep"
         >
-          {nickname} 님이 {accessString}
+          {getAccessString()}
         </span>
       </div>
     </div>

--- a/src/app/(chat)/_components/atoms/UserAccessNotification.tsx
+++ b/src/app/(chat)/_components/atoms/UserAccessNotification.tsx
@@ -1,4 +1,4 @@
-import { AccessStatus } from '@/app/model/Message';
+import { AccessStatus } from '@/app/model/AccessStatus';
 import React from 'react';
 
 type Props = {
@@ -15,9 +15,10 @@ export default function UserAccessNotification({
   const getAccessString = () => {
     let baseStr = `${nickname} 님이`;
 
-    if (access === 'enter') baseStr += '입장했습니다.';
-    else if (access === 'kicked') baseStr += '강퇴 투표로 퇴장 처리되었습니다.';
-    else if (access === 'exit') baseStr += '나갔습니다.';
+    if (access === AccessStatus.ENTER) baseStr += '입장했습니다.';
+    else if (access === AccessStatus.KICKED)
+      baseStr += '강퇴 투표로 퇴장 처리되었습니다.';
+    else if (access === AccessStatus.EXIT) baseStr += '나갔습니다.';
     return baseStr;
   };
 

--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -34,6 +34,7 @@ import isNull from '@/utils/validation/validateIsNull';
 import { useWebSocketClient } from '@/store/webSocket';
 import { useEnter } from '@/store/enter';
 import { kickedUsers } from '@/store/kickedUser';
+import { AccessStatus } from '@/app/model/AccessStatus';
 import BackButton from '../../../_components/atoms/BackButton';
 import AgoraInfo from '../molecules/AgoraInfo';
 import DiscussionStatus from '../molecules/DiscussionStatus';
@@ -227,11 +228,12 @@ export default function Header() {
       const { socketDisconnectTime, username, memberId } =
         response.data.agoraMemberInfo;
 
-      let accessStatus: 'enter' | 'kicked' | 'exit';
+      let accessStatus: AccessStatus;
 
-      if (isNull(socketDisconnectTime)) accessStatus = 'enter';
-      else if (kickedUsers.hasUserName(username)) accessStatus = 'kicked';
-      else accessStatus = 'exit';
+      if (isNull(socketDisconnectTime)) accessStatus = AccessStatus.ENTER;
+      else if (kickedUsers.hasUserName(username))
+        accessStatus = AccessStatus.KICKED;
+      else accessStatus = AccessStatus.EXIT;
 
       updateUserAccessMessage(
         queryClient,

--- a/src/app/(chat)/_components/organisms/Header.tsx
+++ b/src/app/(chat)/_components/organisms/Header.tsx
@@ -10,16 +10,9 @@ import { AgoraMeta } from '@/app/model/AgoraMeta';
 import { useChatInfo } from '@/store/chatInfo';
 import showToast from '@/utils/showToast';
 import { useVoteStore } from '@/store/vote';
-import {
-  InfiniteData,
-  useMutation,
-  useQueryClient,
-} from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import getKey from '@/utils/getKey';
-import {
-  getAgoraUserListQueryKey,
-  getChatMessagesQueryKey,
-} from '@/constants/queryKey';
+import { getAgoraUserListQueryKey } from '@/constants/queryKey';
 import {
   STORAGE_PREVIOUSE_URL_KEY,
   homeSegmentKey,
@@ -34,12 +27,13 @@ import {
   DISCUSSION_TOAST_MESSAGE,
 } from '@/constants/chats';
 import { useUnloadDisconnectSocket } from '@/hooks/useUnloadDisconnectSocket';
-import { Message } from '@/app/model/Message';
+
 import { useMessageStore } from '@/store/message';
 import isNull from '@/utils/validation/validateIsNull';
-import accessMessageConfig from '@/lib/accessMessageConfig';
+
 import { useWebSocketClient } from '@/store/webSocket';
 import { useEnter } from '@/store/enter';
+import { kickedUsers } from '@/store/kickedUser';
 import BackButton from '../../../_components/atoms/BackButton';
 import AgoraInfo from '../molecules/AgoraInfo';
 import DiscussionStatus from '../molecules/DiscussionStatus';
@@ -47,6 +41,7 @@ import patchChatExit from '../../_lib/patchChatExit';
 import SocketErrorHandler from '../../utils/SocketErrorHandler';
 import { resetStateOnChatExit } from '../../utils/resetStateOnChatExit';
 import MenuItems from '../molecules/MenuItems';
+import { updateUserAccessMessage } from '../../utils/updateUserAccessMessage';
 
 export default function Header() {
   const { toggle } = useSidebarStore(
@@ -187,71 +182,6 @@ export default function Header() {
     );
   };
 
-  const updateUserAccessMessage = (
-    userDisconnectTime: string,
-    enterAgoraId: number,
-    username: string,
-  ) => {
-    const curMessages = queryClient.getQueryData(
-      getChatMessagesQueryKey(enterAgora.id),
-    ) as InfiniteData<{
-      chats: Message[];
-      meta: { key: number; effectiveSize: number };
-    }>;
-
-    if (isNull(username) || isNull(curMessages)) return;
-
-    const newMessages = {
-      pageParams: [...curMessages.pageParams],
-      pages: [...curMessages.pages],
-    };
-
-    const lastPage = newMessages.pages.at(-1);
-
-    const newLastPage =
-      lastPage?.meta.key === -1
-        ? { chats: [...lastPage.chats], meta: { ...lastPage.meta } }
-        : { chats: [], meta: { key: 0, effectiveSize: 20 } };
-
-    // const lastMessageId = lastPage?.chats.at(-1)?.chatId;
-
-    const newMessage = {
-      chatId: accessMessageConfig.getAccessMessageChatId(),
-      user: {
-        id: -1,
-        nickname: username,
-        photoNumber: 0,
-        type: '',
-      },
-      content: '',
-      createdAt: '',
-      reactionCount: {
-        LIKE: 0,
-        DISLIKE: 0,
-        LOVE: 0,
-        HAPPY: 0,
-        SAD: 0,
-      },
-      access: userDisconnectTime === null ? 'enter' : 'exit',
-    };
-
-    newLastPage.chats.push(newMessage);
-
-    newMessages.pages[newMessages.pages.length - 1] = {
-      chats: newLastPage.chats,
-      meta: {
-        key: newLastPage.meta.key || 0,
-        effectiveSize: 20,
-      },
-    };
-
-    queryClient.setQueryData(
-      getChatMessagesQueryKey(enterAgoraId),
-      newMessages,
-    );
-    setGoDown(true);
-  };
-
   const updateParticipantList = (
     userDisconnectTime: string,
     memberId: number,
@@ -297,12 +227,21 @@ export default function Header() {
       const { socketDisconnectTime, username, memberId } =
         response.data.agoraMemberInfo;
 
+      let accessStatus: 'enter' | 'kicked' | 'exit';
+
+      if (isNull(socketDisconnectTime)) accessStatus = 'enter';
+      else if (kickedUsers.hasUserName(username)) accessStatus = 'kicked';
+      else accessStatus = 'exit';
+
       updateUserAccessMessage(
-        socketDisconnectTime,
+        queryClient,
         response.data.agora.id,
         username,
+        accessStatus,
       );
+      setGoDown(true);
       updateParticipantList(socketDisconnectTime, memberId, username);
+      kickedUsers.removeUserName(memberId);
     } else if (response.type === DISCUSSION_START) {
       // console.log(data.data);
       showToast('토론이 시작되었습니다.', 'success');

--- a/src/app/(chat)/utils/resetStateOnChatExit.ts
+++ b/src/app/(chat)/utils/resetStateOnChatExit.ts
@@ -1,6 +1,7 @@
 import { useAgora } from '@/store/agora';
 import { useChatInfo } from '@/store/chatInfo';
 import { useEnter } from '@/store/enter';
+import { kickedUsers } from '@/store/kickedUser';
 import { useSidebarStore } from '@/store/sidebar';
 import { useUploadImage } from '@/store/uploadImage';
 
@@ -11,4 +12,5 @@ export const resetStateOnChatExit = () => {
   useUploadImage.getState().resetUploadImageState();
   useChatInfo.getState().reset();
   useSidebarStore.getState().reset();
+  kickedUsers.reset();
 };

--- a/src/app/(chat)/utils/updateUserAccessMessage.tsx
+++ b/src/app/(chat)/utils/updateUserAccessMessage.tsx
@@ -1,0 +1,67 @@
+import { getChatMessagesQueryKey } from '@/constants/queryKey';
+import { InfiniteData, QueryClient } from '@tanstack/react-query';
+import { AccessStatus, Message } from '@/app/model/Message';
+import accessMessageConfig from '@/lib/accessMessageConfig';
+import isNull from '@/utils/validation/validateIsNull';
+
+export const updateUserAccessMessage = (
+  queryClient: QueryClient,
+  enterAgoraId: number,
+  username: string,
+  accessStatus: AccessStatus,
+) => {
+  const curMessages = queryClient.getQueryData(
+    getChatMessagesQueryKey(enterAgoraId),
+  ) as InfiniteData<{
+    chats: Message[];
+    meta: { key: number; effectiveSize: number };
+  }>;
+
+  if (isNull(username) || isNull(curMessages)) return;
+
+  const newMessages = {
+    pageParams: [...curMessages.pageParams],
+    pages: [...curMessages.pages],
+  };
+
+  const lastPage = newMessages.pages.at(-1);
+
+  const newLastPage =
+    lastPage?.meta.key === -1
+      ? { chats: [...lastPage.chats], meta: { ...lastPage.meta } }
+      : { chats: [], meta: { key: 0, effectiveSize: 20 } };
+
+  // const lastMessageId = lastPage?.chats.at(-1)?.chatId;
+
+  const newMessage = {
+    chatId: accessMessageConfig.getAccessMessageChatId(),
+    user: {
+      id: -1,
+      nickname: username,
+      photoNumber: 0,
+      type: '',
+    },
+    content: '',
+    createdAt: '',
+    reactionCount: {
+      LIKE: 0,
+      DISLIKE: 0,
+      LOVE: 0,
+      HAPPY: 0,
+      SAD: 0,
+    },
+    access: accessStatus,
+  };
+
+  newLastPage.chats.push(newMessage);
+
+  newMessages.pages[newMessages.pages.length - 1] = {
+    chats: newLastPage.chats,
+    meta: {
+      key: newLastPage.meta.key || 0,
+      effectiveSize: 20,
+    },
+  };
+
+  queryClient.setQueryData(getChatMessagesQueryKey(enterAgoraId), newMessages);
+};

--- a/src/app/_components/utils/SetChatInfoReset.tsx
+++ b/src/app/_components/utils/SetChatInfoReset.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import isNull from '@/utils/validation/validateIsNull';
 import { usePathname } from 'next/navigation';
-import { useChatInfo } from '@/store/chatInfo';
+import { resetStateOnChatExit } from '@/app/(chat)/utils/resetStateOnChatExit';
 
 export default function SetChatInfoReset() {
   const {
@@ -18,12 +18,6 @@ export default function SetChatInfoReset() {
       selectedAgora: state.selectedAgora,
       enterAgoraReset: state.enterAgoraReset,
       reset: state.reset,
-    })),
-  );
-
-  const { resetParticipants } = useChatInfo(
-    useShallow((state) => ({
-      resetParticipants: state.resetParticipants,
     })),
   );
 
@@ -42,7 +36,7 @@ export default function SetChatInfoReset() {
         agoraInfoReset();
         userProfileReset();
         selectedAgoraInfoReset();
-        resetParticipants();
+        resetStateOnChatExit();
 
         useAgora.persist.rehydrate();
         useEnter.persist.rehydrate();

--- a/src/app/model/AccessStatus.ts
+++ b/src/app/model/AccessStatus.ts
@@ -1,0 +1,5 @@
+export enum AccessStatus {
+  ENTER = 'ENTER',
+  KICKED = 'KICKED',
+  EXIT = 'EXIT',
+}

--- a/src/app/model/Agora.ts
+++ b/src/app/model/Agora.ts
@@ -99,6 +99,7 @@ export type KickVoteResponse = {
   type: string;
   kickVoteInfo: {
     targetMemberId: number;
+    nickname: string;
     message: string;
   };
 };

--- a/src/app/model/Message.ts
+++ b/src/app/model/Message.ts
@@ -5,9 +5,8 @@
 //   content: string;
 //   createdAt: string;
 // }
+import { AccessStatus } from './AccessStatus';
 import { Reaction } from './Reaction';
-
-export type AccessStatus = 'enter' | 'exit' | 'kicked';
 
 export interface Message {
   chatId: number;

--- a/src/app/model/Message.ts
+++ b/src/app/model/Message.ts
@@ -7,6 +7,8 @@
 // }
 import { Reaction } from './Reaction';
 
+export type AccessStatus = 'enter' | 'exit' | 'kicked';
+
 export interface Message {
   chatId: number;
   user: {
@@ -18,5 +20,5 @@ export interface Message {
   content: string;
   createdAt: string;
   reactionCount: Reaction;
-  access?: string;
+  access?: AccessStatus;
 }

--- a/src/store/kickedUser.ts
+++ b/src/store/kickedUser.ts
@@ -1,0 +1,25 @@
+class KickedUsers {
+  #nicknames: Set<string>;
+
+  constructor() {
+    this.#nicknames = new Set();
+  }
+
+  addUserName(username: string) {
+    this.#nicknames.add(username);
+  }
+
+  removeUserName(username: string) {
+    this.#nicknames.delete(username);
+  }
+
+  hasUserName(username: string) {
+    return this.#nicknames.has(username);
+  }
+
+  reset() {
+    this.#nicknames = new Set();
+  }
+}
+
+export const kickedUsers = new KickedUsers();

--- a/src/store/kickedUser.ts
+++ b/src/store/kickedUser.ts
@@ -18,7 +18,7 @@ class KickedUsers {
   }
 
   reset() {
-    this.#nicknames = new Set();
+    this.#nicknames.clear();
   }
 }
 


### PR DESCRIPTION
### 🛠 개발 기능

- 채팅방 유저 강퇴시 다른 사용자들에게 강퇴 메시지 가도록 구현

### 🧩 해결 방법

- 강퇴 당한 사용자 목록이 렌더링에 영향을 주지 않기에, 전역 상태가 아닌 싱글턴 패턴을 사용해 전역에서 접근 가능한 객체를 만들었습니다.
- 유저가 퇴장할 때 모두에게 전송되는 메타 정보를 처리할 때, 강퇴 당한 사용자 목록에 해당 유저가 존재할 경우, 해당 유저가 강제퇴장 당했음을 알리도록 하는 메시지를 띄우도록 했습니다.

### 🔍 리뷰 포인트

- 리뷰 시 어떤 부분에 집중해야 할지 명시해주세요.

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
