### PR TITLE
채팅방 웹 접근성 개선 (스크린리더)

### DIFF
--- a/src/app/(main)/_components/atoms/AgoraPointColor.tsx
+++ b/src/app/(main)/_components/atoms/AgoraPointColor.tsx
@@ -12,7 +12,6 @@ export default function AgoraPointColor({ isCheck, color }: Props) {
     >
       {isCheck && (
         <svg
-          aria-label="선택한 색상"
           xmlns="http://www.w3.org/2000/svg"
           height="25"
           viewBox="0 -960 960 960"

--- a/src/app/(main)/_components/atoms/CategoryAgora.tsx
+++ b/src/app/(main)/_components/atoms/CategoryAgora.tsx
@@ -137,8 +137,13 @@ function CategoryAgora({ agora, className }: Props) {
       const { pros, cons, observer } = agoraData.participants;
       baseStr += `현재 찬성자는 ${pros}명, 반대자는 ${cons}명, 관찰자는 ${observer} 명입니다.`;
     } else {
-      const { prosCount, consCount } = agoraData;
-      baseStr += `토론에 참여했던 찬성자는 ${prosCount}명, 반대자는 ${consCount}명 입니다.`;
+      const { prosCount, consCount, totalMember } = agoraData;
+      const prosWidth =
+        prosCount <= 0 ? 0 : Math.floor((prosCount / totalMember) * 100);
+      const consWidth =
+        consCount <= 0 ? 0 : Math.floor((consCount / totalMember) * 100);
+
+      baseStr += `토론에 참여했던 인원은 ${totalMember}명이며, 찬성 ${prosWidth}%, 반대 ${consWidth}% 로 종료되었습니다.`;
     }
 
     baseStr += '입장하시겠습니까?';

--- a/src/app/(main)/_components/atoms/CategoryAgora.tsx
+++ b/src/app/(main)/_components/atoms/CategoryAgora.tsx
@@ -96,10 +96,28 @@ function CategoryAgora({ agora, className }: Props) {
     return '입장하기';
   }, []);
 
+  function getAgoraIntroduceString(agoraData: AgoraData) {
+    let baseStr = `${agoraData.agoraTitle},`;
+
+    if (isActiveAgora(agoraData)) {
+      const { pros, cons, observer } = agoraData.participants;
+      baseStr += `현재 찬성자는 ${pros}명, 반대자는 ${cons}명, 관찰자는 ${observer} 명입니다.`;
+
+      return baseStr;
+    }
+    const { prosCount, consCount } = agoraData;
+
+    baseStr += `토론에 참여했던 찬성자는 ${prosCount}명, 반대자는 ${consCount}명 입니다.`;
+    return baseStr;
+  }
+
   return (
     <article
+      /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+      tabIndex={0}
       id={`${agora.id}`}
       className={`${className} w-165 under-mobile:w-130 p-10 border-1 rounded-lg flex flex-col justify-center items-center dark:bg-dark-light-300 dark:border-dark-light-600 border-slate-200 bg-slate-50`}
+      aria-label={getAgoraIntroduceString(agora)}
     >
       <div
         className={`${selectedColor} under-mobile:w-3rem under-mobile:h-3rem w-4rem h-4rem rounded-3xl under-mobile:rounded-2xl relative`}

--- a/src/app/(main)/_components/atoms/CategoryAgora.tsx
+++ b/src/app/(main)/_components/atoms/CategoryAgora.tsx
@@ -15,6 +15,11 @@ import Loading from '@/app/_components/atoms/loading';
 import useApiError from '@/hooks/useApiError';
 import ClosedAgoraVoteResultBar from './ClosedAgoraVoteResultBar';
 import { postEnterClosedAgora } from '../../_lib/postEnterClosedAgora';
+import {
+  getAgoraDetailString,
+  getAgoraIntroduceString,
+} from '../../utils/getScreenReaderString';
+import useScreenReaderClickOutside from '../hooks/useScreenReaderClickOutside';
 
 type Props = {
   agora: AgoraData;
@@ -126,46 +131,7 @@ function CategoryAgora({ agora, className }: Props) {
     buttonRef.current?.focus();
   }
 
-  function getAgoraIntroduceString(agoraData: AgoraData) {
-    return `${agoraData.agoraTitle}. 아고라 세부 정보를 들으시려면 엔터키를 누르세요.`;
-  }
-
-  function getAgoraDetailString(agoraData: AgoraData) {
-    let baseStr = '';
-
-    if (isActiveAgora(agoraData)) {
-      const { pros, cons, observer } = agoraData.participants;
-      baseStr += `현재 찬성자는 ${pros}명, 반대자는 ${cons}명, 관찰자는 ${observer} 명입니다.`;
-    } else {
-      const { prosCount, consCount, totalMember } = agoraData;
-      const prosWidth =
-        prosCount <= 0 ? 0 : Math.floor((prosCount / totalMember) * 100);
-      const consWidth =
-        consCount <= 0 ? 0 : Math.floor((consCount / totalMember) * 100);
-
-      baseStr += `토론에 참여했던 인원은 ${totalMember}명이며, 찬성 ${prosWidth}%, 반대 ${consWidth}% 로 종료되었습니다.`;
-    }
-
-    baseStr += '입장하시겠습니까?';
-
-    return baseStr;
-  }
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (
-        articleRef.current &&
-        !articleRef.current.contains(e.target as Node)
-      ) {
-        setIsActiveScreenReaderDetails(false);
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, []);
+  useScreenReaderClickOutside(articleRef, setIsActiveScreenReaderDetails);
 
   return (
     <article

--- a/src/app/(main)/_components/atoms/ControlNumberInput.tsx
+++ b/src/app/(main)/_components/atoms/ControlNumberInput.tsx
@@ -9,6 +9,8 @@ type Props = {
   increaseLabel: string;
   decreaseLabel: string;
   inputLabel: string;
+  max: number;
+  min: number;
 };
 
 export default function ControlNumberInput({
@@ -19,6 +21,8 @@ export default function ControlNumberInput({
   increaseLabel,
   decreaseLabel,
   inputLabel,
+  max,
+  min,
 }: Props) {
   return (
     <label
@@ -38,6 +42,8 @@ export default function ControlNumberInput({
         <input
           id="modify-number-input"
           aria-label={inputLabel}
+          min={min}
+          max={max}
           value={value}
           onChange={handleChange}
           type="number"

--- a/src/app/(main)/_components/atoms/KeywordAgora.tsx
+++ b/src/app/(main)/_components/atoms/KeywordAgora.tsx
@@ -16,6 +16,7 @@ import { useMutation } from '@tanstack/react-query';
 import useApiError from '@/hooks/useApiError';
 import ClosedAgoraVoteResultBar from './ClosedAgoraVoteResultBar';
 import { postEnterClosedAgora } from '../../_lib/postEnterClosedAgora';
+import { getAgoraDetailString } from '../../utils/getScreenReaderString';
 
 type Props = {
   agora: AgoraData;
@@ -89,7 +90,7 @@ export default function KeywordAgora({ agora }: Props) {
       <div
         role="button"
         tabIndex={0}
-        aria-label="아고라"
+        aria-label={`${agora.agoraTitle}, ${getAgoraDetailString(agora)}`}
         onKeyDown={handleKeyDownEnterAgora}
         onClick={handleEnterAgora}
         className="w-full flex mb-15 pb-15 pl-1rem pr-1rem justify-center items-center cursor-pointer border-b-1 border-gray-100 dark:border-0"

--- a/src/app/(main)/_components/atoms/NoAgoraMessage.tsx
+++ b/src/app/(main)/_components/atoms/NoAgoraMessage.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 export default function NoAgoraMessage() {
   return (
-    <div className="flex flex-col items-center justify-start pt-12 pb-32">
-      <p
-        aria-label="출력된 텍스트"
-        className="text-gray-500 dark:text-dark-line-light text-sm"
-      >
+    <div
+      className="flex flex-col items-center justify-start pt-12 pb-32"
+      /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+      tabIndex={0}
+      /* 사용자가 없는 아고라를 건너뛰기 보다, 직접 방이 없음을 인식하는게 낫다고 판단하여 tabIndex 적용하였음. */
+    >
+      <p className="text-gray-500 dark:text-dark-line-light text-sm">
         아직 등록된 아고라가 없습니다.
       </p>
     </div>

--- a/src/app/(main)/_components/atoms/RouteAnnouncer.tsx
+++ b/src/app/(main)/_components/atoms/RouteAnnouncer.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import React, { useEffect, useState } from 'react';
+
+function RouteAnnouncer() {
+  const pathname = usePathname();
+  const [announcement, setAnnouncement] = useState('');
+
+  useEffect(() => {
+    setAnnouncement('');
+    const announceTimer = setTimeout(() => {
+      let newMessage = '';
+      if (pathname === '/home') {
+        newMessage = '해당 페이지에서 아고라를 검색하거나 입장할 수 있습니다.';
+      } else if (pathname === '/create-agora') {
+        newMessage = '해당 페이지에서 아고라를 생성할 수 있습니다.';
+      } else if (pathname === '/user-info') {
+        newMessage =
+          '해당 페이지에서 유저 정보를 확인하거나 조작할 수 있습니다';
+      }
+
+      if (newMessage) {
+        setAnnouncement(newMessage);
+      }
+    }, 500);
+
+    return () => clearTimeout(announceTimer);
+  }, [pathname]);
+
+  return (
+    <>
+      {/* 항상 존재하는 정적 컨테이너 */}
+      <div className="sr-only" aria-live="assertive">
+        {/* 동적으로 변경되는 내용 */}
+        {announcement ? <p>{announcement}</p> : null}
+      </div>
+    </>
+  );
+}
+
+export default RouteAnnouncer;

--- a/src/app/(main)/_components/atoms/SearchBar.tsx
+++ b/src/app/(main)/_components/atoms/SearchBar.tsx
@@ -99,11 +99,9 @@ function SearchBar() {
         type="button"
         aria-label="입력한 검색 텍스트 전체 삭제"
         className="flex justify-center items-center w-1.5rem h-1.5rem"
+        onClick={removeAllInputText}
       >
-        <RemoveIcon
-          className="w-19 cursor-pointer"
-          onClick={removeAllInputText}
-        />
+        <RemoveIcon className="w-19 cursor-pointer" />
       </button>
     </div>
   );

--- a/src/app/(main)/_components/atoms/ThemeSwitcher.tsx
+++ b/src/app/(main)/_components/atoms/ThemeSwitcher.tsx
@@ -13,6 +13,7 @@ type Props = {
 
 export default function ThemeSwitcher({ theme }: Props) {
   const [isDarkMode, setIsDarkMode] = useState(theme === THEME.DARK);
+  const [statusMessage, setStatusMessage] = useState('');
 
   const handleToggleTheme = async () => {
     const currentTheme = await toggleThemeValue();
@@ -30,20 +31,25 @@ export default function ThemeSwitcher({ theme }: Props) {
       metaThemeColor.setAttribute('content', THEME_CONTENT.LIGHT);
 
       setIsDarkMode(false);
+      setStatusMessage('라이트 모드로 바뀌었습니다.');
     } else if (currentTheme === THEME.DARK) {
       document.documentElement.classList.add(THEME.DARK);
       document.documentElement.setAttribute('data-theme', THEME.DARK);
       metaThemeColor.setAttribute('content', THEME_CONTENT.DARK);
 
       setIsDarkMode(true);
+      setStatusMessage('다크 모드로 바뀌었습니다.');
     }
   };
 
   return (
     <div>
+      <div aria-live="polite" className="sr-only">
+        {statusMessage}
+      </div>
       {!isDarkMode ? (
         <button
-          aria-label="다크모드로 바꾸기"
+          aria-label="다크모드로 전환"
           type="button"
           onClick={handleToggleTheme}
         >
@@ -51,7 +57,7 @@ export default function ThemeSwitcher({ theme }: Props) {
         </button>
       ) : (
         <button
-          aria-label="라이트모드로 바꾸기"
+          aria-label="라이트모드로 전환"
           type="button"
           onClick={handleToggleTheme}
         >

--- a/src/app/(main)/_components/hooks/useScreenReaderClickOutside.tsx
+++ b/src/app/(main)/_components/hooks/useScreenReaderClickOutside.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+function useScreenReaderClickOutside(
+  ref: React.RefObject<HTMLElement>,
+  setIsActive: React.Dispatch<React.SetStateAction<boolean>>,
+) {
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsActive(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref, setIsActive]);
+}
+
+export default useScreenReaderClickOutside;

--- a/src/app/(main)/_components/molecules/CategoryButtonList.tsx
+++ b/src/app/(main)/_components/molecules/CategoryButtonList.tsx
@@ -96,7 +96,7 @@ export default function CategoryButtonList() {
           {Object.values(AGORACATEGORY).map((category) => (
             <button
               type="button"
-              aria-label="카테고리"
+              aria-label={`${category.innerText} 카테고리`}
               onClick={() => setCategory(category.value)}
               className="swiper-slide"
               key={category.innerText}

--- a/src/app/(main)/_components/molecules/DiscussionDurationSetter.tsx
+++ b/src/app/(main)/_components/molecules/DiscussionDurationSetter.tsx
@@ -34,7 +34,9 @@ export default function DiscussionDurationSetter() {
       <div className="flex justify-start items-center">
         <input
           aria-label="토론 제한시간 입력창"
-          type="number"
+          min={AGORA_CREATE.MIN_DISCUSSION_TIME}
+          max={AGORA_CREATE.MAX_DISCUSSION_TIME}
+          type="text"
           value={duration || ''}
           onChange={validateAgoraDuration}
           className="input-number-hide focus-visible:outline-none text-sm mr-0.5rem text-center p-5 w-4rem lg:w-5rem border-1 border-athens-gray rounded-md dark:bg-dark-bg-light dark:border-gray-500"

--- a/src/app/(main)/_components/molecules/LivelyAgoraList.tsx
+++ b/src/app/(main)/_components/molecules/LivelyAgoraList.tsx
@@ -158,7 +158,7 @@ export default function LivelyAgoraList() {
         🔥 실시간 HOT 아고라
         <button
           type="button"
-          aria-label="활발한 아고라 다시 불러오기"
+          aria-label="인기 아고라 다시 불러오기"
           onClick={handleClickRefresh}
           onKeyDown={handleKeyDownRefresh}
           className="cursor-pointer flex font-normal mr-5"

--- a/src/app/(main)/_components/molecules/PageTitle.tsx
+++ b/src/app/(main)/_components/molecules/PageTitle.tsx
@@ -14,10 +14,7 @@ async function PageTitle({ title, desc, children = null }: Props) {
   return (
     <>
       <div className="flex justify-between items-center">
-        <h1
-          aria-label="페이지 제목"
-          className="text-lg lg:text-xl font-bold w-full flex justify-start items-center dark:text-white"
-        >
+        <h1 className="text-lg lg:text-xl font-bold w-full flex justify-start items-center dark:text-white">
           {title}
         </h1>
         <ThemeSwitcher theme={theme || THEME.LIGHT} />

--- a/src/app/(main)/_components/molecules/ParticipantCapacitySetter.tsx
+++ b/src/app/(main)/_components/molecules/ParticipantCapacitySetter.tsx
@@ -63,6 +63,8 @@ function ParticipantCapacitySetter() {
           increaseLabel="참여 인원 증가"
           decreaseLabel="참여 인원 감소"
           inputLabel="설정한 최대 참여 인원"
+          max={AGORA_CREATE.MAX_PARTICIPANTS_CNT}
+          min={AGORA_CREATE.MIN_PARTICIPANTS_CNT}
         />
       </div>
       <div>

--- a/src/app/(main)/_components/molecules/SelectAgoraColor.tsx
+++ b/src/app/(main)/_components/molecules/SelectAgoraColor.tsx
@@ -29,7 +29,7 @@ export default function SelectAgoraColor() {
       {Array.from({ length: COLOR.length }, (_, i) => (
         <button
           type="button"
-          aria-label={`${COLOR[i].label}`}
+          aria-label={`${COLOR[i].label} ${isCheck === i ? '선택됨' : ''}`}
           key={i}
           onClick={() => selectColor(i)}
         >

--- a/src/app/(main)/_components/organisms/NavMenu.tsx
+++ b/src/app/(main)/_components/organisms/NavMenu.tsx
@@ -5,6 +5,9 @@ import DesktopNav from '../templates/DesktopNav';
 function SideNav() {
   return (
     <nav className="lg:h-dvh flex-1 max-w-12rem flex-grow">
+      <p className="sr-only" role="status">
+        해당 페이지에서 아고라를 검색하거나 입장할 수 있습니다.
+      </p>
       <DesktopNav />
       <MobileNav />
     </nav>

--- a/src/app/(main)/_components/organisms/NavMenu.tsx
+++ b/src/app/(main)/_components/organisms/NavMenu.tsx
@@ -1,41 +1,14 @@
-import Link from 'next/link';
-import Image from 'next/image';
 import React from 'react';
-import Athens from '@/assets/icons/Athens';
-import NavLinks from '../molecules/NavLinks';
+import MobileNav from '../templates/MobileNav';
+import DesktopNav from '../templates/DesktopNav';
 
 function SideNav() {
   return (
     <nav className="lg:h-dvh flex-1 max-w-12rem flex-grow">
-      <div className="hidden lg:block fixed h-dvh xl:w-12rem lg:w-12rem pl-1rem border-r-1 border-r-gray-50 bg-white dark:bg-dark-light-300 dark:border-dark-light-300">
-        <div className="w-lg flex flex-col">
-          <div className="flex-col">
-            <Link
-              prefetch
-              aria-label="로고로 홈 돌아가기"
-              href="/"
-              className="flex flex-row items-center text-2xl pt-1rem pb-1rem p-1rem"
-            >
-              <Image
-                src="/logo.png"
-                alt="Athens 로고"
-                className="mr-14"
-                width={32}
-                height={32}
-              />
-              <Athens className="w-65" />
-            </Link>
-            <NavLinks />
-          </div>
-        </div>
-      </div>
-      <div className="block lg:hidden w-full min-w-300 fixed bottom-0rem bg-white z-10 dark:bg-dark-light-300">
-        <div className="w-lg flex flex-row justify-center items-center">
-          <NavLinks />
-        </div>
-      </div>
+      <DesktopNav />
+      <MobileNav />
     </nav>
   );
 }
 
-export default React.memo(SideNav);
+export default SideNav;

--- a/src/app/(main)/_components/organisms/NavMenu.tsx
+++ b/src/app/(main)/_components/organisms/NavMenu.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import MobileNav from '../templates/MobileNav';
 import DesktopNav from '../templates/DesktopNav';
+import RouteAnnouncer from '../atoms/RouteAnnouncer';
 
 function SideNav() {
   return (
     <nav className="lg:h-dvh flex-1 max-w-12rem flex-grow">
-      <p className="sr-only" role="status">
-        해당 페이지에서 아고라를 검색하거나 입장할 수 있습니다.
-      </p>
+      <RouteAnnouncer />
       <DesktopNav />
       <MobileNav />
     </nav>

--- a/src/app/(main)/_components/templates/DesktopNav.tsx
+++ b/src/app/(main)/_components/templates/DesktopNav.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import Athens from '@/assets/icons/Athens';
+import NavLinks from '../molecules/NavLinks';
+
+function DesktopNav() {
+  return (
+    <div className="hidden lg:block fixed h-dvh xl:w-12rem lg:w-12rem pl-1rem border-r-1 border-r-gray-50 bg-white dark:bg-dark-light-300 dark:border-dark-light-300">
+      <div className="w-lg flex flex-col">
+        <div className="flex-col">
+          <Link
+            prefetch
+            href="/"
+            className="flex flex-row items-center text-2xl pt-1rem pb-1rem p-1rem"
+          >
+            <Image
+              src="/logo.png"
+              alt="Athens 로고"
+              aria-label="홈으로 돌아가기"
+              className="mr-14"
+              width={32}
+              height={32}
+            />
+            <Athens className="w-65" />
+          </Link>
+          <NavLinks />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DesktopNav;

--- a/src/app/(main)/_components/templates/DesktopNav.tsx
+++ b/src/app/(main)/_components/templates/DesktopNav.tsx
@@ -17,7 +17,7 @@ function DesktopNav() {
             <Image
               src="/logo.png"
               alt="Athens 로고"
-              aria-label="홈으로 돌아가기"
+              aria-label="로고로 홈 돌아가기"
               className="mr-14"
               width={32}
               height={32}

--- a/src/app/(main)/_components/templates/Main.tsx
+++ b/src/app/(main)/_components/templates/Main.tsx
@@ -13,10 +13,7 @@ const AgoraListDeciderHydration = dynamic(
 
 export default function Main({ searchParams }: Props) {
   return (
-    <main
-      aria-label="아고라 리스트"
-      className="justify-center items-stretch flex flex-col h-dvh flex-1 relative"
-    >
+    <main className="justify-center items-stretch flex flex-col h-dvh flex-1 relative">
       <div className="flex h-full flex-col p-5 pt-3 pb-5rem justify-start items-center">
         <Suspense
           fallback={

--- a/src/app/(main)/_components/templates/MobileNav.tsx
+++ b/src/app/(main)/_components/templates/MobileNav.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import NavLinks from '../molecules/NavLinks';
+
+function MobileNav() {
+  return (
+    <div className="block lg:hidden w-full min-w-300 fixed bottom-0rem bg-white z-10 dark:bg-dark-light-300">
+      <div className="w-lg flex flex-row justify-center items-center">
+        <NavLinks />
+      </div>
+    </div>
+  );
+}
+
+export default MobileNav;

--- a/src/app/(main)/create-agora/_component/AgoraTitleInput.tsx
+++ b/src/app/(main)/create-agora/_component/AgoraTitleInput.tsx
@@ -46,7 +46,8 @@ export default function AgoraTitleInput() {
   return (
     <>
       <input
-        aria-label="생성할 아고라 주제 입력창"
+        id="agora-title"
+        aria-label="아고라 주제 입력창"
         type="text"
         value={title}
         onChange={changeInput}
@@ -54,7 +55,11 @@ export default function AgoraTitleInput() {
         className="placeholder:text-athens-gray-thick w-full p-0.5rem text-sm border-1 border-gray-300 rounded-md dark:bg-dark-light-300 dark:placeholder:text-white dark:placeholder:text-opacity-85 dark:border-0 dark:text-white"
       />
       {message && (
-        <div className="text-xs text-red-600 p-5 pl-0 dark:text-dark-con-color">
+        <div
+          aria-live="polite"
+          role="alert"
+          className="text-xs text-red-600 p-5 pl-0 dark:text-dark-con-color"
+        >
           {message}
         </div>
       )}

--- a/src/app/(main)/create-agora/_component/AgoraTitleInput.tsx
+++ b/src/app/(main)/create-agora/_component/AgoraTitleInput.tsx
@@ -54,11 +54,7 @@ export default function AgoraTitleInput() {
         className="placeholder:text-athens-gray-thick w-full p-0.5rem text-sm border-1 border-gray-300 rounded-md dark:bg-dark-light-300 dark:placeholder:text-white dark:placeholder:text-opacity-85 dark:border-0 dark:text-white"
       />
       {message && (
-        <div
-          aria-live="polite"
-          role="alert"
-          className="text-xs text-red-600 p-5 pl-0 dark:text-dark-con-color"
-        >
+        <div className="text-xs text-red-600 p-5 pl-0 dark:text-dark-con-color">
           {message}
         </div>
       )}

--- a/src/app/(main)/create-agora/page.tsx
+++ b/src/app/(main)/create-agora/page.tsx
@@ -10,7 +10,7 @@ import CreateAgoraImageUpload from './_component/CreateAgoraImageUpload';
 
 export async function generateMetadata() {
   return {
-    title: '아고라 생성 - Athens',
+    title: '아고라 생성',
     description: '사람들과 이야기하고 싶은 주제로 아고라를 만들어보세요.',
     openGraph: {
       title: '아고라 생성 - Athens',

--- a/src/app/(main)/flow/enter-agora/_components/SelectProfile.tsx
+++ b/src/app/(main)/flow/enter-agora/_components/SelectProfile.tsx
@@ -6,11 +6,13 @@ import { PROFLELIST } from '@/constants/consts';
 import { useShallow } from 'zustand/react/shallow';
 import { useEnter } from '@/store/enter';
 import { ProfileImage } from '@/app/model/Agora';
+import { AGORA_POSITION } from '@/constants/agora';
 
 export default function SelectProfile() {
-  const { setProfileImage } = useEnter(
+  const { setProfileImage, selectedPosition } = useEnter(
     useShallow((state) => ({
       setProfileImage: state.setProfileImage,
+      selectedPosition: state.selectedPosition,
     })),
   );
 
@@ -32,28 +34,32 @@ export default function SelectProfile() {
       aria-label="사용할 프로필 이미지 선택"
       className="grid grid-cols-5 under-mobile:grid-cols-4 mobile:grid-cols-4 foldable:grid-cols-5 tablet:flex gap-y-5  pl-1rem"
     >
-      {PROFLELIST.map((profileImageName) => (
-        <li
-          key={profileImageName.id}
-          className="cursor-pointer mr-5 w-fit flex justify-center items-center rounded-full"
-        >
-          <div
-            role="button"
-            tabIndex={0}
-            aria-label={profileImageName.name}
-            onClick={() => selectProfile(profileImageName)}
-            onKeyDown={(e) => handleKeyDownSetProfile(e, profileImageName)}
+      {PROFLELIST.map((profileImageName) => {
+        const isDisabled = selectedPosition === AGORA_POSITION.OBSERVER;
+
+        return (
+          <li
+            key={profileImageName.id}
+            className="cursor-pointer mr-5 w-fit flex justify-center items-center rounded-full"
           >
-            <UserImage
-              className="rounded-full w-45 h-45 bg-white"
-              file={profileImageName.file}
-              name={profileImageName.name}
-              w={45}
-              h={45}
-            />
-          </div>
-        </li>
-      ))}
+            <button
+              type="button"
+              disabled={isDisabled}
+              aria-label={profileImageName.name}
+              onClick={() => selectProfile(profileImageName)}
+              onKeyDown={(e) => handleKeyDownSetProfile(e, profileImageName)}
+            >
+              <UserImage
+                className="rounded-full w-45 h-45 bg-white"
+                file={profileImageName.file}
+                name={profileImageName.name}
+                w={45}
+                h={45}
+              />
+            </button>
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ searchParams }: Props) {
   const title = searchParams.q ? `${searchParams.q} - Athens` : '';
   const category = searchParams.category
     ? `${value?.innerText} - Athens`
-    : 'Athens';
+    : '홈';
 
   return {
     title: title || category,

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -7,7 +7,6 @@ import SignIn from './_components/templates/SignIn';
 
 export async function generateMetadata() {
   return {
-    title: 'Athens',
     description: '실시간 익명 채팅으로 광장에서 자유롭게 이야기하세요.',
     openGraph: {
       title: 'Athens',

--- a/src/app/(main)/user-info/_component/atoms/AccountInfo.tsx
+++ b/src/app/(main)/user-info/_component/atoms/AccountInfo.tsx
@@ -8,11 +8,14 @@ type Props = {
 
 export default function AccountInfo({ label, content, className }: Props) {
   return (
-    <div
+    <dl
       className={`flex flex-wrap justify-between items-center p-2 space-y-6 ${className}`}
+      /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+      tabIndex={0}
+      aria-readonly
     >
-      <span className="text-sm dark:text-white">{label}</span>
-      <span className="text-sm dark:text-white">{content}</span>
-    </div>
+      <dt className="text-sm dark:text-white">{label}</dt>
+      <dd className="text-sm dark:text-white">{content}</dd>
+    </dl>
   );
 }

--- a/src/app/(main)/user-info/_component/atoms/ActionButton.tsx
+++ b/src/app/(main)/user-info/_component/atoms/ActionButton.tsx
@@ -6,13 +6,19 @@ type Props = {
   className?: string;
 };
 export default function ActionButton({ label, onClick, className }: Props) {
+  function handleOnKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
+    if (e.key === 'Enter') {
+      onClick?.();
+    }
+  }
+
   return (
     <button
       type="button"
       className={className}
       onClick={onClick}
-      onKeyDown={onClick}
-      aria-label={`${label} 버튼`}
+      onKeyDown={handleOnKeyDown}
+      aria-label={`${label}`}
     >
       {label}
     </button>

--- a/src/app/(main)/user-info/page.tsx
+++ b/src/app/(main)/user-info/page.tsx
@@ -1,6 +1,28 @@
 import React from 'react';
 import UserInfoMain from './_component/organisms/UserInfoMain';
 
+export async function generateMetadata() {
+  return {
+    title: '사용자 정보',
+    description:
+      '사용자 정보를 확인하거나 로그아웃 및 회원 탈퇴를 이용할 수 있어요.',
+    openGraph: {
+      title: '사용자 정보',
+      description:
+        '사용자 정보를 확인하거나 로그아웃 및 회원 탈퇴를 이용할 수 있어요.',
+      type: 'website',
+      images: [
+        {
+          url: `${process.env.NEXT_PUBLIC_CLIENT_URL}/opengraph.png`,
+          width: 1200,
+          height: 630,
+          alt: 'Athens 로고',
+        },
+      ],
+    },
+  };
+}
+
 export default function Page() {
   return <UserInfoMain />;
 }

--- a/src/app/(main)/utils/getScreenReaderString.ts
+++ b/src/app/(main)/utils/getScreenReaderString.ts
@@ -1,0 +1,27 @@
+import { AgoraData } from '@/app/model/Agora';
+import isActiveAgora from '@/utils/validation/validateIsActiveAgora';
+
+export function getAgoraIntroduceString(agoraData: AgoraData) {
+  return `${agoraData.agoraTitle}. 아고라 세부 정보를 들으시려면 엔터키를 누르세요.`;
+}
+
+export function getAgoraDetailString(agoraData: AgoraData) {
+  let baseStr = '';
+
+  if (isActiveAgora(agoraData)) {
+    const { pros, cons, observer } = agoraData.participants;
+    baseStr += `현재 찬성자는 ${pros}명, 반대자는 ${cons}명, 관찰자는 ${observer} 명입니다.`;
+  } else {
+    const { prosCount, consCount, totalMember } = agoraData;
+    const prosWidth =
+      prosCount <= 0 ? 0 : Math.floor((prosCount / totalMember) * 100);
+    const consWidth =
+      consCount <= 0 ? 0 : Math.floor((consCount / totalMember) * 100);
+
+    baseStr += `토론에 참여했던 인원은 ${totalMember}명이며, 찬성 ${prosWidth}%, 반대 ${consWidth}% 로 종료되었습니다.`;
+  }
+
+  baseStr += '입장하시겠습니까?';
+
+  return baseStr;
+}

--- a/src/app/_components/atoms/ImageCropperHeader.tsx
+++ b/src/app/_components/atoms/ImageCropperHeader.tsx
@@ -1,0 +1,53 @@
+import React, { forwardRef, KeyboardEvent } from 'react';
+import BackIcon from '@/assets/icons/BackIcon';
+import CheckIcon from '@/assets/icons/CheckIcon';
+
+type CropImgHeaderProps = {
+  handleCancelCrop: () => void;
+  handleKeyDownCancelCrop: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
+  handleImgCrop: () => void;
+  handleKeyDownImgCrop: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
+};
+
+const ImageCropperHeader = forwardRef<HTMLButtonElement, CropImgHeaderProps>(
+  (
+    {
+      handleCancelCrop,
+      handleKeyDownCancelCrop,
+      handleImgCrop,
+      handleKeyDownImgCrop,
+    },
+    ref,
+  ) => (
+    <header
+      aria-label="이미지 자르기 작업 메뉴"
+      className="dark:text-dark-line-light text-dark-bg-dark font-semibold flex flex-row justify-between items-center p-10"
+    >
+      <button
+        ref={ref}
+        type="button"
+        aria-label="이미지 변경 취소하기"
+        className="font-normal flex items-center gap-x-5 flex-grow basis-1/3 focus:focus-sr"
+        onClick={handleCancelCrop}
+        onKeyDown={handleKeyDownCancelCrop}
+      >
+        <BackIcon className="w-20 h-20 " />
+        취소
+      </button>
+      <h1 className="flex flex-grow basis-1/3 justify-center items-center ">
+        자르기
+      </h1>
+      <button
+        className="flex flex-grow basis-1/3 justify-end items-center"
+        aria-label="이미지 변경 완료"
+        onClick={handleImgCrop}
+        onKeyDown={handleKeyDownImgCrop}
+        type="button"
+      >
+        <CheckIcon className="w-25 h-25" />
+      </button>
+    </header>
+  ),
+);
+
+export default React.memo(ImageCropperHeader);

--- a/src/app/_components/molecules/ImageCropper.tsx
+++ b/src/app/_components/molecules/ImageCropper.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import BackIcon from '@/assets/icons/BackIcon';
-import CheckIcon from '@/assets/icons/CheckIcon';
 import React, {
   KeyboardEvent,
   useCallback,
@@ -24,50 +22,7 @@ import showToast from '@/utils/showToast';
 import isNull from '@/utils/validation/validateIsNull';
 import Loading from '../atoms/loading';
 import ImageRenderer from '../atoms/ImageRenderer';
-
-type CropImgHeaderProps = {
-  handleCancelCrop: () => void;
-  handleKeyDownCancelCrop: (e: KeyboardEvent<HTMLButtonElement>) => void;
-  handleImgCrop: () => void;
-  handleKeyDownImgCrop: (e: KeyboardEvent<HTMLButtonElement>) => void;
-};
-
-const Header = React.memo(
-  ({
-    handleCancelCrop,
-    handleKeyDownCancelCrop,
-    handleImgCrop,
-    handleKeyDownImgCrop,
-  }: CropImgHeaderProps) => (
-    <header
-      aria-label="이미지 자르기 작업 메뉴"
-      className="dark:text-dark-line-light text-dark-bg-dark font-semibold flex flex-row justify-between items-center p-10"
-    >
-      <button
-        type="button"
-        aria-label="이미지 변경 취소하기"
-        className="font-normal flex items-center gap-x-5 flex-grow basis-1/3"
-        onClick={handleCancelCrop}
-        onKeyDown={handleKeyDownCancelCrop}
-      >
-        <BackIcon className="w-20 h-20" />
-        취소
-      </button>
-      <h1 className="flex flex-grow basis-1/3 justify-center items-center">
-        자르기
-      </h1>
-      <button
-        className="flex flex-grow basis-1/3 justify-end items-center"
-        aria-label="이미지 변경 완료"
-        onClick={handleImgCrop}
-        onKeyDown={handleKeyDownImgCrop}
-        type="button"
-      >
-        <CheckIcon className="w-25 h-25" />
-      </button>
-    </header>
-  ),
-);
+import ImageCropperHeader from '../atoms/ImageCropperHeader';
 
 export default function ImageCropper() {
   const [crop, setCrop] = useState<Crop>();
@@ -91,6 +46,7 @@ export default function ImageCropper() {
     })),
   );
   const router = useRouter();
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
 
   const onImageLoaded = (e: HTMLImageElement) => {
     const { width, height } = e;
@@ -182,11 +138,13 @@ export default function ImageCropper() {
     [handleCancelCrop],
   );
 
+  function setInitialFocus() {
+    cancelButtonRef.current?.focus();
+  }
+
   useEffect(() => {
     setOpacity('opacity-100');
-    if (dialogRef.current) {
-      dialogRef.current?.focus();
-    }
+    setInitialFocus();
   }, []);
 
   const renderMedia = (file: { dataUrl: string; file: File }) => {
@@ -223,7 +181,8 @@ export default function ImageCropper() {
         <main
           className={`${opacity} transition duration-300 transform scale-100 h-full w-full`}
         >
-          <Header
+          <ImageCropperHeader
+            ref={cancelButtonRef}
             handleCancelCrop={handleCancelCrop}
             handleImgCrop={handleImgCrop}
             handleKeyDownCancelCrop={handleKeyDownCancelCrop}

--- a/src/app/_components/organisms/AgoraImageUpload.tsx
+++ b/src/app/_components/organisms/AgoraImageUpload.tsx
@@ -45,7 +45,10 @@ export default function AgoraImageUpload({ image = '', page, color }: Props) {
   const [viewPopup, setViewPopup] = useState(false);
   const [popupPosition, setPopupPosition] = useState('top');
   const imageRef = useRef<HTMLInputElement>(null);
-  const popupRef = useRef<HTMLDivElement>(null);
+  const imageBtnRef = useRef<HTMLDivElement>(null);
+  const popupRef = useRef<HTMLButtonElement>(null);
+  const imageChoiceRef = useRef<HTMLButtonElement>(null);
+
   const router = useRouter();
 
   useEffect(() => {
@@ -79,22 +82,31 @@ export default function AgoraImageUpload({ image = '', page, color }: Props) {
     }
   };
 
+  const handleViewPopup = (status: boolean) => {
+    if (status) {
+      setViewPopup(true);
+      imageChoiceRef.current?.focus();
+    } else {
+      setViewPopup(false);
+    }
+  };
+
   const clickFileInput = () => {
     imageRef.current?.click();
-    setViewPopup(false);
+    handleViewPopup(false);
   };
 
   const removeImage = () => {
     setUploadImage(initialCropedPreview);
     setCropedPreview(initialCropedPreview);
-    setViewPopup(false);
+    handleViewPopup(false);
   };
 
   const calculatePopupPosition = () => {
-    if (popupRef.current) {
-      const popupTop = popupRef.current.getBoundingClientRect().top;
+    if (imageBtnRef.current) {
+      const popupTop = imageBtnRef.current.getBoundingClientRect().top;
       const popupBottom =
-        window.innerHeight - popupRef.current.getBoundingClientRect().bottom;
+        window.innerHeight - imageBtnRef.current.getBoundingClientRect().bottom;
 
       if (popupTop < popupBottom) {
         setPopupPosition('bottom');
@@ -106,33 +118,35 @@ export default function AgoraImageUpload({ image = '', page, color }: Props) {
 
   const viewPopupHandler = () => {
     calculatePopupPosition();
-    setViewPopup(true);
+    handleViewPopup(true);
   };
 
   const handleClickOutside = (event: MouseEvent) => {
     if (popupRef.current && !popupRef.current.contains(event.target as Node)) {
-      setViewPopup(false);
+      handleViewPopup(false);
     }
   };
 
-  const handlleKeyDown = (e: KeyboardEvent) => {
+  const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Enter') {
-      setViewPopup(false);
+      handleViewPopup(false);
+    } else if (e.key === 'Escape') {
+      handleViewPopup(false);
     }
   };
 
   useEffect(() => {
     if (viewPopup) {
       document.addEventListener('mousedown', handleClickOutside);
-      document.addEventListener('keydown', handlleKeyDown);
+      document.addEventListener('keydown', handleKeyDown);
     } else {
       document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handlleKeyDown);
+      document.removeEventListener('keydown', handleKeyDown);
     }
 
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handlleKeyDown);
+      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [viewPopup]);
 
@@ -140,6 +154,7 @@ export default function AgoraImageUpload({ image = '', page, color }: Props) {
     e,
   ) => {
     if (e.key === 'Enter') {
+      e.preventDefault();
       viewPopupHandler();
     }
   };
@@ -175,8 +190,8 @@ export default function AgoraImageUpload({ image = '', page, color }: Props) {
       <div
         role="button"
         tabIndex={0}
-        aria-label="클릭하여 아고라 프로필 설정"
-        ref={popupRef}
+        aria-label="아고라 프로필 설정"
+        ref={imageBtnRef}
         className="relative w-60 h-60 rounded-3xl under-mobile:rounded-2xl cursor-pointer"
         onClick={viewPopupHandler}
         onKeyDown={handleKeyDownPopupHandler}
@@ -205,29 +220,33 @@ export default function AgoraImageUpload({ image = '', page, color }: Props) {
           <CameraIcon className="w-14 h-14" fill="#fffff" />
         </div>
       </div>
-      <div
+      <button
+        type="button"
         role="menu"
-        aria-label="이미지 선택 및 제거 선택 팝업메뉴"
-        ref={popupRef}
         className={`transform transition-opacity duration-300 ease-out ${viewPopup ? 'opacity-100 z-10' : 'opacity-0 pointer-events-none'} cursor-pointer rounded-md gap-20 flex flex-col absolute ${popupPosition === 'top' ? 'bottom-10' : 'top-1/2'} left-50 p-10 dark:bg-dark-light-200 bg-dark-light-500 text-white text-xs`}
+        ref={popupRef}
+        tabIndex={-1}
       >
         <button
           role="menuitem"
           type="button"
-          className="break-keep"
+          className="break-keep focus:outline-none focus:ring-2 focus:ring-white focus:ring-opacity-75 rounded px-2 py-1"
           onClick={clickFileInput}
+          ref={imageChoiceRef}
+          tabIndex={viewPopup ? 0 : -1}
         >
           이미지 선택
         </button>
         <button
           role="menuitem"
           type="button"
-          className="break-keep"
+          className="break-keep focus:outline-none focus:ring-2 focus:ring-white focus:ring-opacity-75 rounded px-2 py-1"
           onClick={removeImage}
+          tabIndex={viewPopup ? 0 : -1}
         >
           이미지 제거
         </button>
-      </div>
+      </button>
     </div>
   );
 }

--- a/src/app/_components/organisms/AgoraImageUpload.tsx
+++ b/src/app/_components/organisms/AgoraImageUpload.tsx
@@ -230,7 +230,7 @@ export default function AgoraImageUpload({ image = '', page, color }: Props) {
         <button
           role="menuitem"
           type="button"
-          className="break-keep focus:outline-none focus:ring-2 focus:ring-white focus:ring-opacity-75 rounded px-2 py-1"
+          className="break-keep focus:focus-sr rounded px-2 py-1"
           onClick={clickFileInput}
           ref={imageChoiceRef}
           tabIndex={viewPopup ? 0 : -1}
@@ -240,7 +240,7 @@ export default function AgoraImageUpload({ image = '', page, color }: Props) {
         <button
           role="menuitem"
           type="button"
-          className="break-keep focus:outline-none focus:ring-2 focus:ring-white focus:ring-opacity-75 rounded px-2 py-1"
+          className="break-keep focus:focus-sr rounded px-2 py-1"
           onClick={removeImage}
           tabIndex={viewPopup ? 0 : -1}
         >

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,10 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
-  title: 'Athens',
+  title: {
+    default: 'Athens',
+    template: '%s - Athens',
+  },
   description: 'Athens | 실시간 익명 채팅으로 광장에서 자유롭게 토론하세요.',
   manifest: '/manifest.json',
   icons: [

--- a/src/app/model/Agora.ts
+++ b/src/app/model/Agora.ts
@@ -1,16 +1,17 @@
 import { AGORA_STATUS } from '@/constants/agora';
 
 export type Status = (typeof AGORA_STATUS)[keyof typeof AGORA_STATUS];
+export type Participants = {
+  pros: number;
+  cons: number;
+  observer: number;
+};
 
 export interface Agora {
   id: number;
   agoraTitle: string;
   agoraColor: string;
-  participants: {
-    pros: number;
-    cons: number;
-    observer: number;
-  };
+  participants: Participants;
   imageUrl: string;
   createdAt?: string;
   status: Status;

--- a/src/assets/icons/RemoveIcon.tsx
+++ b/src/assets/icons/RemoveIcon.tsx
@@ -3,14 +3,9 @@ import React from 'react';
 type Props = {
   className?: string;
   onClick?: () => void;
-  label?: string;
 };
 
-function RemoveIcon({
-  className = '',
-  onClick = () => {},
-  label = 'X 아이콘',
-}: Props) {
+function RemoveIcon({ className = '', onClick = () => {} }: Props) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -18,7 +13,6 @@ function RemoveIcon({
       fill="var(--icon-color-remove)"
       className={className}
       onClick={onClick}
-      aria-label={label}
     >
       <path d="m256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z" />
     </svg>

--- a/src/utils/swalAlert.ts
+++ b/src/utils/swalAlert.ts
@@ -98,7 +98,7 @@ let timerInterval: ReturnType<typeof setInterval>;
 export const swalDeleteAccountSuccessAlert = async () => {
   return swalDeleteAccountSuccessAlertClass.fire({
     width: '300px',
-    title: '계정이 삭제 되었습니다',
+    title: '계정을 삭제 하는 중입니다..',
     html: '<b></b> 초 뒤에 로그인 화면으로 이동합니다.',
     timer: 5000,
     timerProgressBar: true,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -103,41 +103,50 @@ const config: Config = {
   },
   plugins: [
     ({ addUtilities }: any) => {
-      addUtilities({
-        '.scrollbar-hide': {
-          scrollbarWidth: 'none',
-          '-ms-overflow-style': 'none',
-          '&::-webkit-scrollbar': {
-            display: 'none',
+      addUtilities(
+        {
+          '.scrollbar-hide': {
+            scrollbarWidth: 'none',
+            '-ms-overflow-style': 'none',
+            '&::-webkit-scrollbar': {
+              display: 'none',
+            },
           },
-        },
-        '.text-xxs': {
-          fontSize: '0.625rem',
-        },
-        '.text-xxxs': {
-          fontSize: '0.5rem',
-        },
-        '.max-width-screen': {
-          maxWidth: '1580px',
-        },
-        '.input-number-hide': {
-          '&::-webkit-outer-spin-button': {
-            '-webkit-appearance': 'none',
-            margin: 0,
+          '.text-xxs': {
+            fontSize: '0.625rem',
           },
-          '&::-webkit-inner-spin-button': {
-            '-webkit-appearance': 'none',
-            margin: 0,
+          '.text-xxxs': {
+            fontSize: '0.5rem',
           },
-          '-moz-appearance': {
+          '.max-width-screen': {
+            maxWidth: '1580px',
+          },
+          '.input-number-hide': {
+            '&::-webkit-outer-spin-button': {
+              '-webkit-appearance': 'none',
+              margin: 0,
+            },
+            '&::-webkit-inner-spin-button': {
+              '-webkit-appearance': 'none',
+              margin: 0,
+            },
+            '-moz-appearance': {
+              appearance: 'textfield',
+            },
             appearance: 'textfield',
           },
-          appearance: 'textfield',
+          '.transform-scale-y-inverted': {
+            transform: 'scaleY(-1)',
+          },
+          '.focus-sr': {
+            outline: 'none',
+            '--tw-ring-opacity': '0.75',
+            '--tw-ring-color': 'rgb(255 255 255 / var(--tw-ring-opacity))',
+            'box-shadow': '0 0 0 2px var(--tw-ring-color)',
+          },
         },
-        '.transform-scale-y-inverted': {
-          transform: 'scaleY(-1)',
-        },
-      });
+        ['focus'],
+      );
     },
   ],
 };


### PR DESCRIPTION
### 🔗 Linked Issue

- [ ] #205

resolved: #1 #2

### 🛠 개발 기능

- 적절한 시맨틱 태그가 필요한 부분 수정
- 웹 접근성 4원칙을 최대한 지킬 수 있도록, 스크린 리더 및 탭 동작 수정
(탭 포커스가 되어야 하지만, div와 같은 속성일 경우, tabIndex 0 값을 통해 적절히 조정. 
반면에, 기본적으로 포커스가 되지만, 스크린리더가 읽어줄 필요가 없을 경우 tabIndex -1 값을 통해 조정)
- 아고라 생성, 사용자 정보, 카테고리 및 키워드 아고라 리스트 등의 내용을 사용자에게 읽어주도록 WAI-ARIA 속성 활용

### 🧩 해결 방법

- 카테고리 아고라 리스트에서, 사용자에게 아고라 리스트에 관한 정보를 한 번에 읽어주는 것은 정보 과다라고 생각했습니다. 
아고라가 포커스되었을 때는 제목만 읽어주고, 포커스된 아고라에서 "Enter" 키를 눌렀을 경우, 세부 정보를 들을 수 있도록 하였습니다.
- 키워드 아고라는 입장하기 버튼이 없기 때문에, 위와 같은 방식으로 적용할 경우 두 번에 나눠서 아고라를 입장 해야한다는 번거로움이 있을 수 있어, 어쩔 수 없이 한 번에 모든 정보를 읽어주는 것으로 대체하였습니다.
- 스크린 리더를 켰을 때, `ref.current.focus()`  로 직접 포커스 시킨 대상은 포커스 테두리가 나타나지 않아서, `focus-sr` 커스텀 속성을 추가해 사용자가 인식할 수 있도록 했습니다. `focus:focus-sr` 을 통해 적용시킬 수 있습니다.



### 🔍 리뷰 포인트

- 부적절 및 과다 사용된 WAI-ARIA 속성을 발견하시거나, 추가, 개선되었으면 하는 내용이 있다면 코멘트 부탁드립니다!

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
