### PR TITLE
Refactor/chat type

### DIFF
--- a/src/app/(chat)/_components/atoms/DiscussionTimer.tsx
+++ b/src/app/(chat)/_components/atoms/DiscussionTimer.tsx
@@ -33,7 +33,7 @@ export default function DiscussionTimer({ duration }: Props) {
   const router = useRouter();
 
   const agoraEndMutation = useMutation({
-    mutationFn: async () => patchAgoraTimeOut(enterAgora.id),
+    mutationFn: async () => patchAgoraTimeOut({ agoraId: enterAgora.id }),
     onSuccess: async (response) => {
       if (response) {
         router.push(`/agoras/${enterAgora.id}/flow/end-agora`);

--- a/src/app/(chat)/_components/molecules/AgoraUserList.tsx
+++ b/src/app/(chat)/_components/molecules/AgoraUserList.tsx
@@ -78,9 +78,9 @@ export default function AgoraUserList({
       currentMemberCount,
       agoraId,
     }: KickMutationProps) =>
-      postKickVote(targetMemberId, currentMemberCount, agoraId),
+      postKickVote({ targetMemberId, currentMemberCount, agoraId }),
     onSuccess: (response) => {
-      if (response.success) {
+      if (response) {
         showToast('강퇴 투표에 성공하였습니다.', 'success');
         return;
       }

--- a/src/app/(chat)/_components/molecules/DiscussionStatus.tsx
+++ b/src/app/(chat)/_components/molecules/DiscussionStatus.tsx
@@ -35,7 +35,7 @@ export default function DiscussionStatus({ meta }: Props) {
   );
 
   const agoraStartMutation = useMutation({
-    mutationFn: async () => patchAgoraStart(enterAgora.id),
+    mutationFn: async () => patchAgoraStart({ agoraId: enterAgora.id }),
     onMutate: () => {},
     onSuccess: async (response) => {
       if (!response) {
@@ -48,7 +48,7 @@ export default function DiscussionStatus({ meta }: Props) {
   });
 
   const agoraEndMutation = useMutation({
-    mutationFn: async () => patchAgoraEnd(enterAgora.id),
+    mutationFn: async () => patchAgoraEnd({ agoraId: enterAgora.id }),
     onSuccess: async (response) => {
       if (response) {
         setIsEndClicked(true);

--- a/src/app/(chat)/_components/molecules/MessageInput.tsx
+++ b/src/app/(chat)/_components/molecules/MessageInput.tsx
@@ -190,7 +190,7 @@ export default function MessageInput() {
 
   const filterBadWordsMutation = useMutation({
     mutationFn: callFilterBadWordsAPI,
-    onSuccess: async ({ response }) => {
+    onSuccess: async (response) => {
       if (response.hasBadWord) {
         highlightBadWords(response.badword);
         showToast('부적절한 단어가 포함되어 있습니다.', 'error');

--- a/src/app/(chat)/_components/organisms/Message.tsx
+++ b/src/app/(chat)/_components/organisms/Message.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Message as IMessage } from '@/app/model/Message';
+import { Message as IMessage, MessageMetaResponse } from '@/app/model/Message';
 import React, {
   FocusEventHandler,
   KeyboardEventHandler,
@@ -34,11 +34,6 @@ import ChatNotification from '../atoms/ChatNotification';
 import NotificationNewMessage from '../atoms/NotificationNewMessage';
 import ScrollToBottomBtn from '../atoms/ScrollToBottomBtn';
 import MessageItem from '../molecules/MessageItem';
-
-interface Meta {
-  key: number | null;
-  effectiveSize: number;
-}
 
 export default function Message() {
   const [newMessageView, setNewMessageView] = useState<boolean>(false);
@@ -89,11 +84,11 @@ export default function Message() {
     isFetchingPreviousPage,
     fetchPreviousPage,
   } = useSuspenseInfiniteQuery<
-    { chats: IMessage[]; meta: Meta },
+    { chats: IMessage[]; meta: MessageMetaResponse },
     Object,
-    InfiniteData<{ chats: IMessage[]; meta: Meta }>,
+    InfiniteData<{ chats: IMessage[]; meta: MessageMetaResponse }>,
     [_1: string, _2: string, _3: string],
-    { meta: Meta }
+    { meta: MessageMetaResponse }
   >({
     queryKey: getChatMessagesQueryKey(agoraId),
     queryFn: isNull(session)

--- a/src/app/(chat)/_components/templates/AgoraSideBar.tsx
+++ b/src/app/(chat)/_components/templates/AgoraSideBar.tsx
@@ -42,7 +42,6 @@ export default function AgoraSideBar() {
   };
 
   const onKeyDownOutSide: KeyboardEventHandler<HTMLDivElement> = (e) => {
-    console.log('onKeyDownOutSide', e.key, e.code);
     if (e.key === 'Enter' && e.target === e.currentTarget) {
       toggle();
     } else if (e.key === 'Escape') {

--- a/src/app/(chat)/_components/templates/MessageContainer.tsx
+++ b/src/app/(chat)/_components/templates/MessageContainer.tsx
@@ -5,15 +5,18 @@ import {
 } from '@tanstack/react-query';
 import React from 'react';
 import { getChatMessagesQueryKey } from '@/constants/queryKey';
+import { AgoraId } from '@/app/model/Agora';
 import { getChatMessagesServer } from '../../_lib/getChatMessagesServer';
 import ErrorBoundaryMessage from '../organisms/ErrorBoundaryMessage';
 
-type Props = {
-  agoraId: number;
+type MessageContainerProps = {
+  agoraId: AgoraId;
 };
 
 // 서버 컴포넌트
-export default async function MessageContainer({ agoraId }: Props) {
+export default async function MessageContainer({
+  agoraId,
+}: MessageContainerProps) {
   const queryClient = new QueryClient();
 
   await queryClient.prefetchInfiniteQuery({

--- a/src/app/(chat)/_lib/patchAgoraEnd.ts
+++ b/src/app/(chat)/_lib/patchAgoraEnd.ts
@@ -1,3 +1,4 @@
+import { AgoraId } from '@/app/model/Agora';
 import { AUTH_MESSAGE, SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import {
   AGORA_END,
@@ -7,29 +8,48 @@ import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import isNull from '@/utils/validation/validateIsNull';
 
-export const patchAgoraEnd = async (agoraId: number) => {
+type PatchAgoraEndArg = {
+  agoraId: AgoraId;
+};
+
+type EndDiscussionResponse = {
+  agoraId: AgoraId;
+  endVoteCount: number;
+  isClosed: boolean;
+  endTime: string | null;
+};
+
+export const patchAgoraEnd = async ({
+  agoraId,
+}: PatchAgoraEndArg): Promise<EndDiscussionResponse> => {
   const session = await getSession();
   if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 
-  const res = await callFetchWrapper(`/api/v1/auth/agoras/${agoraId}/close`, {
-    method: 'PATCH',
-    next: {
-      tags: [],
+  const res = await callFetchWrapper<EndDiscussionResponse>(
+    `/api/v1/auth/agoras/${agoraId}/close`,
+    {
+      method: 'PATCH',
+      next: {
+        tags: [],
+      },
+      credentials: 'include',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.user?.accessToken}`,
+      },
     },
-    credentials: 'include',
-    cache: 'no-cache',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${session.user?.accessToken}`,
-    },
-  });
+  );
 
   if (!res.ok && !res.success) {
     if (!res.error) {
       throw new Error(AGORA_END.UNKNOWN_ERROR);
     }
+
+    const errorMessage =
+      typeof res.error.message === 'string' ? res.error.message : 'ERROR';
 
     if (res.error.code === 1301) {
       throw new Error(AGORA_END.NOT_FOUND_AGORA_OR_USER);
@@ -45,13 +65,17 @@ export const patchAgoraEnd = async (agoraId: number) => {
       throw new Error(AGORA_END.OBSERVER_CANNOT_END);
     } else if (res.error.code === 503) {
       throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
-    } else if (AUTH_MESSAGE.includes(res.error.message)) {
-      throw new Error(res.error.message);
+    } else if (AUTH_MESSAGE.includes(errorMessage)) {
+      throw new Error(errorMessage);
     }
 
     throw new Error(AGORA_END.NOT_FOUND_AGORA_OR_USER);
 
     // return null;
+  }
+
+  if (isNull(res.response)) {
+    throw new Error(AGORA_END.UNKNOWN_ERROR);
   }
 
   const result = res.response;

--- a/src/app/(chat)/_lib/patchAgoraImg.ts
+++ b/src/app/(chat)/_lib/patchAgoraImg.ts
@@ -7,13 +7,14 @@ import {
   NETWORK_ERROR_MESSAGE,
 } from '@/constants/responseErrorMessage';
 import isNull from '@/utils/validation/validateIsNull';
+import { AgoraId, ImageURL } from '@/app/model/Agora';
 
-type Props = {
-  agoraId: number;
-  fileUrl: string;
+type PatchAgoraImgArg = {
+  agoraId: AgoraId;
+  fileUrl: ImageURL;
 };
 
-export const patchAgoraImg = async ({ agoraId, fileUrl }: Props) => {
+export const patchAgoraImg = async ({ agoraId, fileUrl }: PatchAgoraImgArg) => {
   const session = await getSession();
   if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
@@ -41,14 +42,17 @@ export const patchAgoraImg = async ({ agoraId, fileUrl }: Props) => {
       throw new Error(AGORA_IMAGE_UPDATE.UNKNOWN_ERROR);
     }
 
+    const errorMessage =
+      typeof res.error.message === 'string' ? res.error.message : 'ERROR';
+
     if (res.error.code === 1202) {
       throw new Error(AGORA_IMAGE_UPDATE.ONLY_HOST_CAN_UPDATE);
     } else if (res.error.code === 1301) {
       throw new Error(AGORA_IMAGE_UPDATE.NOT_FOUND_AGORA_OR_USER);
     } else if (res.error.code === 503) {
       throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
-    } else if (AUTH_MESSAGE.includes(res.error.message)) {
-      throw new Error(res.error.message);
+    } else if (AUTH_MESSAGE.includes(errorMessage)) {
+      throw new Error(errorMessage);
     }
 
     throw new Error(AGORA_IMAGE_UPDATE.FAILED_TO_UPDATE_IMAGE);

--- a/src/app/(chat)/_lib/patchAgoraStart.ts
+++ b/src/app/(chat)/_lib/patchAgoraStart.ts
@@ -1,3 +1,4 @@
+import { AgoraId } from '@/app/model/Agora';
 import { AUTH_MESSAGE, SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import {
   AGORA_START,
@@ -7,29 +8,46 @@ import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import isNull from '@/utils/validation/validateIsNull';
 
-export const patchAgoraStart = async (agoraId: number) => {
+type PatchAgoraStartArg = {
+  agoraId: AgoraId;
+};
+
+type StartDiscussionResponse = {
+  agoraId: AgoraId;
+  startTime: string;
+};
+
+export const patchAgoraStart = async ({
+  agoraId,
+}: PatchAgoraStartArg): Promise<StartDiscussionResponse> => {
   const session = await getSession();
   if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 
-  const res = await callFetchWrapper(`/api/v1/auth/agoras/${agoraId}/start`, {
-    method: 'PATCH',
-    next: {
-      tags: [],
+  const res = await callFetchWrapper<StartDiscussionResponse>(
+    `/api/v1/auth/agoras/${agoraId}/start`,
+    {
+      method: 'PATCH',
+      next: {
+        tags: [],
+      },
+      credentials: 'include',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.user?.accessToken}`,
+      },
     },
-    credentials: 'include',
-    cache: 'no-cache',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${session.user?.accessToken}`,
-    },
-  });
+  );
 
   if (!res.ok && !res.success) {
     if (!res.error) {
       throw new Error(AGORA_START.UNKNOWN_ERROR);
     }
+
+    const errorMessage =
+      typeof res.error.message === 'string' ? res.error.message : 'ERROR';
 
     if (res.error.code === 1002) {
       throw new Error(AGORA_START.ALREADY_RUNNING_OR_ENDED);
@@ -39,12 +57,16 @@ export const patchAgoraStart = async (agoraId: number) => {
       throw new Error(AGORA_START.OBSERVER_CANNOT_START);
     } else if (res.error.code === 503) {
       throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
-    } else if (AUTH_MESSAGE.includes(res.error.message)) {
-      throw new Error(res.error.message);
+    } else if (AUTH_MESSAGE.includes(errorMessage)) {
+      throw new Error(errorMessage);
     }
 
     throw new Error(AGORA_START.FAILED_TO_START_AGORA);
     // return null;
+  }
+
+  if (isNull(res.response)) {
+    throw new Error(AGORA_START.UNKNOWN_ERROR);
   }
 
   const result = res.response;

--- a/src/app/(chat)/_lib/patchAgoraTimeOut.ts
+++ b/src/app/(chat)/_lib/patchAgoraTimeOut.ts
@@ -1,3 +1,4 @@
+import { AgoraId } from '@/app/model/Agora';
 import { AUTH_MESSAGE, SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import {
   AGORA_TIME_OUT,
@@ -7,13 +8,23 @@ import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import isNull from '@/utils/validation/validateIsNull';
 
-export const patchAgoraTimeOut = async (agoraId: number) => {
+type PatchAgoraTimeOutArg = {
+  agoraId: AgoraId;
+};
+
+type TimeOutDiscussionResponse = {
+  agoraId: AgoraId;
+  isClosed: boolean;
+  endTime: string;
+};
+
+export const patchAgoraTimeOut = async ({ agoraId }: PatchAgoraTimeOutArg) => {
   const session = await getSession();
   if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 
-  const res = await callFetchWrapper(
+  const res = await callFetchWrapper<TimeOutDiscussionResponse>(
     `/api/v1/open/agoras/${agoraId}/time-out`,
     {
       method: 'PATCH',
@@ -33,19 +44,26 @@ export const patchAgoraTimeOut = async (agoraId: number) => {
       throw new Error(AGORA_TIME_OUT.UNKNOWN_ERROR);
     }
 
+    const errorMessage =
+      typeof res.error.message === 'string' ? res.error.message : 'ERROR';
+
     if (res.error.code === 1301) {
       throw new Error(AGORA_TIME_OUT.NOT_FOUND_AGORA);
     } else if (res.error.code === 1002) {
       throw new Error(AGORA_TIME_OUT.ALREADY_TIME_OUT);
     } else if (res.error.code === 503) {
       throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
-    } else if (AUTH_MESSAGE.includes(res.error.message)) {
-      throw new Error(res.error.message);
+    } else if (AUTH_MESSAGE.includes(errorMessage)) {
+      throw new Error(errorMessage);
     }
 
     throw new Error(AGORA_TIME_OUT.FAILED_TO_TIME_OUT);
 
     // return null;
+  }
+
+  if (isNull(res.response)) {
+    throw new Error(AGORA_TIME_OUT.UNKNOWN_ERROR);
   }
 
   const result = res.response;

--- a/src/app/(chat)/_lib/patchChatExit.ts
+++ b/src/app/(chat)/_lib/patchChatExit.ts
@@ -1,3 +1,4 @@
+import { AgoraId, ParticipantPosition } from '@/app/model/Agora';
 import { AUTH_MESSAGE, SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import {
   AGORA_EXIT,
@@ -7,51 +8,64 @@ import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import isNull from '@/utils/validation/validateIsNull';
 
-type Props = {
-  agoraId: number;
+type PatchChatExitArg = {
+  agoraId: AgoraId;
 };
 
-const patchChatExit = async ({ agoraId }: Props) => {
+type ChatExitResponse = {
+  userId: number;
+  type: ParticipantPosition;
+  socketDisconnectTime: string;
+};
+
+const patchChatExit = async ({ agoraId }: PatchChatExitArg) => {
   const session = await getSession();
   if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 
-  const res = await callFetchWrapper(`/api/v1/auth/agoras/${agoraId}/exit`, {
-    method: 'PATCH',
-    next: {
-      tags: [],
+  const res = await callFetchWrapper<ChatExitResponse>(
+    `/api/v1/auth/agoras/${agoraId}/exit`,
+    {
+      method: 'PATCH',
+      next: {
+        tags: [],
+      },
+      credentials: 'include',
+      cache: 'no-cache',
+      headers: {
+        Authorization: `Bearer ${session.user?.accessToken}`,
+      },
     },
-    credentials: 'include',
-    cache: 'no-cache',
-    headers: {
-      Authorization: `Bearer ${session.user?.accessToken}`,
-    },
-  });
+  );
 
   if (!res.ok && !res.success) {
     if (!res.error) {
       throw new Error(AGORA_EXIT.UNKNOWN_ERROR);
     }
 
+    const errorMessage =
+      typeof res.error.message === 'string' ? res.error.message : 'ERROR';
+
     if (res.error.code === 1301) {
-      if (
-        res.error.message.startsWith(AGORA_EXIT.SERVER_RESPONSE_NOT_FOUND_AGORA)
-      ) {
+      if (errorMessage.startsWith(AGORA_EXIT.SERVER_RESPONSE_NOT_FOUND_AGORA)) {
         throw new Error(AGORA_EXIT.NOT_FOUND_AGORA);
       } else if (
-        res.error.message.startsWith(AGORA_EXIT.SERVER_RESPONSE_NOT_FOUND_USER)
+        errorMessage.startsWith(AGORA_EXIT.SERVER_RESPONSE_NOT_FOUND_USER)
       ) {
         throw new Error(AGORA_EXIT.NOT_FOUND_USER);
       }
     } else if (res.error.code === 503) {
       throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
-    } else if (AUTH_MESSAGE.includes(res.error.message)) {
-      throw new Error(res.error.message);
+    } else if (AUTH_MESSAGE.includes(errorMessage)) {
+      throw new Error(errorMessage);
     }
 
     throw new Error(AGORA_EXIT.FAILED_TO_EXIT);
-    // return null;
+  }
+
+  if (isNull(res.response)) {
+    throw new Error(AGORA_EXIT.UNKNOWN_ERROR);
   }
 
   const result = res.response;

--- a/src/app/(chat)/_lib/postFilterBadWords.ts
+++ b/src/app/(chat)/_lib/postFilterBadWords.ts
@@ -1,3 +1,5 @@
+import { AgoraId } from '@/app/model/Agora';
+import { BadWordsFilterResponse, Message } from '@/app/model/Message';
 import { AUTH_MESSAGE, SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import {
   FILTER_BAD_WORDS,
@@ -7,18 +9,21 @@ import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import isNull from '@/utils/validation/validateIsNull';
 
-type Props = {
-  message: string;
-  agoraId: number;
+type PostFilterBadWordsArg = {
+  message: Message['content'];
+  agoraId: AgoraId;
 };
 
-const postFilterBadWords = async ({ message, agoraId }: Props) => {
+const postFilterBadWords = async ({
+  message,
+  agoraId,
+}: PostFilterBadWordsArg) => {
   const session = await getSession();
   if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 
-  const res = await callFetchWrapper(
+  const res = await callFetchWrapper<BadWordsFilterResponse>(
     `/api/v1/auth/agoras/${agoraId}/chats/filter`,
     {
       method: 'post',
@@ -39,24 +44,31 @@ const postFilterBadWords = async ({ message, agoraId }: Props) => {
       throw new Error(FILTER_BAD_WORDS.UNKNOWN_ERROR);
     }
 
+    const errorMessage =
+      typeof res.error.message === 'string' ? res.error.message : 'ERROR';
+
     if (res.error.code === 1102) {
       if (
-        res.error.message ===
-        FILTER_BAD_WORDS.SERVER_RESPONSE_USER_NOT_PARTICIPATING
+        errorMessage === FILTER_BAD_WORDS.SERVER_RESPONSE_USER_NOT_PARTICIPATING
       ) {
         throw new Error(FILTER_BAD_WORDS.USER_NOT_PARTICIPATING);
       }
     } else if (res.error.code === 503) {
       throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
-    } else if (AUTH_MESSAGE.includes(res.error.message)) {
-      throw new Error(res.error.message);
+    } else if (AUTH_MESSAGE.includes(errorMessage)) {
+      throw new Error(errorMessage);
     }
 
     throw new Error(FILTER_BAD_WORDS.FAILED_TO_FILTER);
     // return null;
   }
 
-  return res;
+  if (isNull(res.response)) {
+    throw new Error(FILTER_BAD_WORDS.UNKNOWN_ERROR);
+  }
+
+  const result = res.response;
+  return result;
 };
 
 export default postFilterBadWords;

--- a/src/app/(chat)/_lib/postKickVote.ts
+++ b/src/app/(chat)/_lib/postKickVote.ts
@@ -71,10 +71,6 @@ export const postKickVote = async ({
     throw new Error(PATCH_USER_KICK_VOTE_ERROR_MESSAGE.FAILED_TO_KICK_VOTE);
   }
 
-  if (isNull(res.response)) {
-    throw new Error(PATCH_USER_KICK_VOTE_ERROR_MESSAGE.UNKNOWN_ERROR);
-  }
-
   const result = res.response;
   return result;
 };

--- a/src/app/(chat)/_lib/postKickVote.ts
+++ b/src/app/(chat)/_lib/postKickVote.ts
@@ -1,30 +1,39 @@
+import { AgoraId } from '@/app/model/Agora';
+import { AgoraMemberInfo, Participants } from '@/app/model/AgoraMeta';
 import { SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
 import { PATCH_USER_KICK_VOTE_ERROR_MESSAGE } from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import isNull from '@/utils/validation/validateIsNull';
 
-const NOT_FOUND_USER = (agoraId: number, memberId: number) =>
+type MemberId = AgoraMemberInfo['memberId'];
+
+type PostKickVoteArg = {
+  targetMemberId: MemberId;
+  currentMemberCount: Participants['count'];
+  agoraId: AgoraId;
+};
+
+type KickVoteResponse = string;
+
+const NOT_FOUND_USER = (agoraId: AgoraId, memberId: MemberId) =>
   `Agora user not found with agora id: ${agoraId} agoraMemberId: ${memberId}`;
 
-const NOT_FOUND_AGORA = (agoraId: number) =>
+const NOT_FOUND_AGORA = (agoraId: AgoraId) =>
   `Not found agora. agoraId: ${agoraId}`;
 
-export const postKickVote = async (
-  targetMemberId: number,
-  currentMemberCount: number,
-  agoraId: number,
-) => {
-  // Authorization: Bearer accessToken
-  // Cookie: 'ATKN=~'
-
+export const postKickVote = async ({
+  targetMemberId,
+  currentMemberCount,
+  agoraId,
+}: PostKickVoteArg) => {
   const session = await getSession();
 
   if (isNull(session)) {
     throw new Error(SIGNIN_REQUIRED);
   }
 
-  const res = await callFetchWrapper(
+  const res = await callFetchWrapper<KickVoteResponse>(
     `/api/v1/auth/agoras/${agoraId}/kick-vote`,
     {
       method: 'POST',
@@ -50,9 +59,9 @@ export const postKickVote = async (
         throw new Error(PATCH_USER_KICK_VOTE_ERROR_MESSAGE.NOT_FOUND_USER);
       } else if (res.error.message === NOT_FOUND_AGORA(agoraId)) {
         throw new Error(PATCH_USER_KICK_VOTE_ERROR_MESSAGE.NOT_FOUND_AGORA);
-      } else if (res.error.code === 1004) {
-        throw new Error(PATCH_USER_KICK_VOTE_ERROR_MESSAGE.ALREADY_VOTE);
       }
+    } else if (res.error.code === 1004) {
+      throw new Error(PATCH_USER_KICK_VOTE_ERROR_MESSAGE.ALREADY_VOTE);
     }
 
     if (!res.error) {
@@ -62,5 +71,10 @@ export const postKickVote = async (
     throw new Error(PATCH_USER_KICK_VOTE_ERROR_MESSAGE.FAILED_TO_KICK_VOTE);
   }
 
-  return res;
+  if (isNull(res.response)) {
+    throw new Error(PATCH_USER_KICK_VOTE_ERROR_MESSAGE.UNKNOWN_ERROR);
+  }
+
+  const result = res.response;
+  return result;
 };

--- a/src/app/(chat)/agoras/[agora]/page.tsx
+++ b/src/app/(chat)/agoras/[agora]/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSelectedAgoraQueryKey as getSelectedAgoraTags } from '@/constants/queryKey';
+import { AgoraTitleResponse } from '@/app/model/Agora';
 import MessageContainer from '../../_components/templates/MessageContainer';
 
 type Props = {
@@ -11,16 +12,19 @@ export async function generateMetadata({ params }: Props) {
   const agoraId = params.agora;
   let agoraTitle = '';
 
-  const res = await callFetchWrapper(`/api/v1/open/agoras/${agoraId}/title`, {
-    next: {
-      tags: getSelectedAgoraTags(agoraId as string),
+  const res = await callFetchWrapper<AgoraTitleResponse>(
+    `/api/v1/open/agoras/${agoraId}/title`,
+    {
+      next: {
+        tags: getSelectedAgoraTags(agoraId as string),
+      },
+      credentials: 'include',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': 'application/json',
+      },
     },
-    credentials: 'include',
-    cache: 'no-cache',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
+  );
 
   if (!res.ok && !res.success) {
     agoraTitle = '아고라 - Athens';

--- a/src/app/(chat)/utils/updateUserAccessMessage.tsx
+++ b/src/app/(chat)/utils/updateUserAccessMessage.tsx
@@ -4,11 +4,12 @@ import { Message } from '@/app/model/Message';
 import accessMessageConfig from '@/lib/accessMessageConfig';
 import isNull from '@/utils/validation/validateIsNull';
 import { AccessStatus } from '@/app/model/AccessStatus';
+import { AgoraId, AgoraUserProfileType } from '@/app/model/Agora';
 
 export const updateUserAccessMessage = (
   queryClient: QueryClient,
-  enterAgoraId: number,
-  username: string,
+  enterAgoraId: AgoraId,
+  username: AgoraUserProfileType['nickname'],
   accessStatus: AccessStatus,
 ) => {
   const curMessages = queryClient.getQueryData(
@@ -34,13 +35,13 @@ export const updateUserAccessMessage = (
 
   // const lastMessageId = lastPage?.chats.at(-1)?.chatId;
 
-  const newMessage = {
+  const newMessage: Message = {
     chatId: accessMessageConfig.getAccessMessageChatId(),
     user: {
       id: -1,
       nickname: username,
       photoNumber: 0,
-      type: '',
+      type: 'ACCESS',
     },
     content: '',
     createdAt: '',

--- a/src/app/(main)/_lib/getAgoraCategorySearch.ts
+++ b/src/app/(main)/_lib/getAgoraCategorySearch.ts
@@ -22,7 +22,7 @@ export const getAgoraCategorySearch: QueryFunction<
 
   const urlSearchParams = new URLSearchParams(searchParams);
 
-  const res = await callFetchWrapper(
+  const res = await callFetchWrapper<any>(
     `/api/v1/open/agoras?${urlSearchParams.toString()}&next=${pageParam.nextCursor ?? ''}`,
     {
       next: {
@@ -47,25 +47,26 @@ export const getAgoraCategorySearch: QueryFunction<
       throw new Error(AGORA_CATEGORY_SEARCH.UNKNOWN_ERROR);
     }
 
+    const errorMessage =
+      typeof res.error.message === 'string' ? res.error.message : 'ERROR';
+
     if (res.error.code === 1001) {
       throw new Error(AGORA_CATEGORY_SEARCH.NOT_ALLOWED_STATUS);
     } else if (res.error.code === 1301) {
       throw new Error(AGORA_CATEGORY_SEARCH.NOT_ALLOWED_CATEGORY);
     } else if (res.error.code === -1) {
-      throw new Error(res.error.message);
+      throw new Error(errorMessage);
     } else if (res.error.code === 503) {
       throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
     }
 
     throw new Error(AGORA_CATEGORY_SEARCH.FAILED_TO_GET_AGORA_LIST);
-    // return {
-    //   agoras: [],
-    //   nextCursor: null,
-    // };
   }
 
+  const result = res.response;
+
   return {
-    agoras: res.response.agoras,
-    nextCursor: res.response.hasNext ? res.response.next : null,
+    agoras: result.agoras,
+    nextCursor: result.hasNext ? result.next : null,
   };
 };

--- a/src/app/(main)/_lib/getAgoraTitle.ts
+++ b/src/app/(main)/_lib/getAgoraTitle.ts
@@ -7,24 +7,27 @@ import {
   AGORA_INFO,
   NETWORK_ERROR_MESSAGE,
 } from '@/constants/responseErrorMessage';
-import { Status } from '@/app/model/Agora';
+import { AgoraTitleResponse } from '@/app/model/Agora';
 
 export const getAgoraTitle: QueryFunction<
-  { title: string; status: Status | ''; imageUrl: string; agoraColor: string },
+  AgoraTitleResponse,
   [_1: string, _2: string]
 > = async ({ queryKey }) => {
   const [_, agoraId] = queryKey;
 
-  const res = await callFetchWrapper(`/api/v1/open/agoras/${agoraId}/title`, {
-    next: {
-      tags: getSelectedAgoraTags(agoraId),
+  const res = await callFetchWrapper<any>(
+    `/api/v1/open/agoras/${agoraId}/title`,
+    {
+      next: {
+        tags: getSelectedAgoraTags(agoraId),
+      },
+      credentials: 'include',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': 'application/json',
+      },
     },
-    credentials: 'include',
-    cache: 'no-cache',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
+  );
 
   if (!res.ok && !res.success) {
     if (!res.error) {
@@ -38,7 +41,6 @@ export const getAgoraTitle: QueryFunction<
     }
 
     throw new Error(AGORA_INFO.FAILED_TO_GET_AGORA_INFO);
-    // redirect(`${homeSegmentKey}?status=active`);
   }
 
   const result = res.response;

--- a/src/app/(main)/_lib/getLivelyAgora.ts
+++ b/src/app/(main)/_lib/getLivelyAgora.ts
@@ -3,6 +3,7 @@ import {
   NETWORK_ERROR_MESSAGE,
 } from '@/constants/responseErrorMessage';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
+import isNull from '@/utils/validation/validateIsNull';
 
 export const getLivelyAgora = async () => {
   const res = await callFetchWrapper<any>('/api/v1/open/agoras/active', {
@@ -30,7 +31,7 @@ export const getLivelyAgora = async () => {
 
   const result = res.response;
 
-  if (result.agoras.length > 0) {
+  if (!isNull(result.agoras)) {
     return result.agoras;
   }
 

--- a/src/app/(main)/_lib/getLivelyAgora.ts
+++ b/src/app/(main)/_lib/getLivelyAgora.ts
@@ -5,7 +5,7 @@ import {
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 
 export const getLivelyAgora = async () => {
-  const res = await callFetchWrapper('/api/v1/open/agoras/active', {
+  const res = await callFetchWrapper<any>('/api/v1/open/agoras/active', {
     next: {
       tags: ['agoras', 'lively'],
     },
@@ -28,8 +28,10 @@ export const getLivelyAgora = async () => {
     }
   }
 
-  if (res.response.agoras) {
-    return res.response.agoras;
+  const result = res.response;
+
+  if (result.agoras.length > 0) {
+    return result.agoras;
   }
 
   // 인기 아고라가 없을 땐 빈 배열 반환

--- a/src/app/(main)/_lib/postCreateAgora.ts
+++ b/src/app/(main)/_lib/postCreateAgora.ts
@@ -55,7 +55,7 @@ export const postCreateAgora = async (info: AgoraConfig) => {
     throw new Error(SIGNIN_REQUIRED);
   }
 
-  const res = await callFetchWrapper('/api/v1/auth/agoras', {
+  const res = await callFetchWrapper<any>('/api/v1/auth/agoras', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${session.user?.accessToken}`,
@@ -101,12 +101,14 @@ export const postCreateAgora = async (info: AgoraConfig) => {
       }
     } else if (res.error.code === 503) {
       throw new Error(NETWORK_ERROR_MESSAGE.OFFLINE);
-    } else if (AUTH_MESSAGE.includes(res.error.message)) {
+    } else if (
+      typeof res.error.message === 'string' &&
+      AUTH_MESSAGE.includes(res.error.message)
+    ) {
       throw new Error(res.error.message);
     }
 
     throw new Error(AGORA_CREATE.FAIED_TO_CREATE_AGORA);
-    // return null;
   }
 
   const result = res.response;

--- a/src/app/(main)/_lib/postEnterAgoraInfo.ts
+++ b/src/app/(main)/_lib/postEnterAgoraInfo.ts
@@ -31,7 +31,7 @@ export const postEnterAgoraInfo = async ({ info, agoraId }: Props) => {
     throw new Error(SIGNIN_REQUIRED);
   }
 
-  const res = await callFetchWrapper(
+  const res = await callFetchWrapper<any>(
     `/api/v1/auth/agoras/${agoraId}/participants`,
     {
       method: 'post',
@@ -54,8 +54,11 @@ export const postEnterAgoraInfo = async ({ info, agoraId }: Props) => {
       throw new Error(AGORA_ENTER.UNKNOWN_ERROR);
     }
 
-    if (AUTH_MESSAGE.includes(res.error.message)) {
-      throw new Error(res.error.message);
+    const errorMessage =
+      typeof res.error.message === 'string' ? res.error.message : 'ERROR';
+
+    if (AUTH_MESSAGE.includes(errorMessage)) {
+      throw new Error(errorMessage);
     }
 
     if (res.error.code === 1001) {
@@ -71,17 +74,17 @@ export const postEnterAgoraInfo = async ({ info, agoraId }: Props) => {
         throw new Error(AGORA_ENTER.NOT_ALLOWED_POSITION);
       }
     } else if (res.error.code === 1002) {
-      if (res.error.message === AGORA_ENTER.SERVER_RESPONSE_CLOSED_AGORA) {
+      if (errorMessage === AGORA_ENTER.SERVER_RESPONSE_CLOSED_AGORA) {
         return AGORA_STATUS.CLOSED;
       }
     } else if (res.error.code === 1004) {
       if (
-        splitMessage(res.error.message) ===
+        splitMessage(errorMessage) ===
         AGORA_ENTER.SERVER_RESPONSE_ALREADY_PARTICIPATED
       ) {
         throw new Error(AGORA_ENTER.ALREADY_PARTICIPATED);
       } else if (
-        splitMessage(res.error.message) ===
+        splitMessage(errorMessage) ===
         AGORA_ENTER.SERVER_RESPONSE_NICKNAME_DUPLICATED
       ) {
         throw new Error(AGORA_ENTER.NICKNAME_DUPLICATED);

--- a/src/app/(main)/_lib/postEnterClosedAgora.ts
+++ b/src/app/(main)/_lib/postEnterClosedAgora.ts
@@ -13,7 +13,7 @@ export const postEnterClosedAgora = async (agoraId: number) => {
     throw new Error(SIGNIN_REQUIRED);
   }
 
-  const res = await callFetchWrapper(
+  const res = await callFetchWrapper<any>(
     `/api/v1/auth/agoras/${agoraId}/closed/participants`,
     {
       method: 'post',
@@ -30,8 +30,11 @@ export const postEnterClosedAgora = async (agoraId: number) => {
       throw new Error(AGORA_ENTER.UNKNOWN_ERROR);
     }
 
-    if (AUTH_MESSAGE.includes(res.error.message)) {
-      throw new Error(res.error.message);
+    const errorMessage =
+      typeof res.error.message === 'string' ? res.error.message : 'ERROR';
+
+    if (AUTH_MESSAGE.includes(errorMessage)) {
+      throw new Error(errorMessage);
     }
     if (res.error.code === 1002) {
       throw new Error(AGORA_ENTER.ACTIVATE_AGORA);

--- a/src/app/(main)/user-info/_lib/deleteUserAccount.ts
+++ b/src/app/(main)/user-info/_lib/deleteUserAccount.ts
@@ -11,7 +11,7 @@ const deleteUserAccount = async () => {
     throw new Error(SIGNIN_REQUIRED);
   }
 
-  const res = await callFetchWrapper('/api/v1/auth/member', {
+  const res = await callFetchWrapper<any>('/api/v1/auth/member', {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
@@ -20,7 +20,11 @@ const deleteUserAccount = async () => {
     credentials: 'include',
   });
 
-  if (!res.ok && !isNull(res.error?.message)) {
+  if (!res.ok && !res.success) {
+    if (!res.error) {
+      throw new Error(DELETE_USER_ERROR_MESSAGE.UNKNOWN_ERROR);
+    }
+
     if (res.error.code === 1301) {
       throw new Error(DELETE_USER_ERROR_MESSAGE.NOT_FOUND_USER);
     }

--- a/src/app/(main)/user-info/_lib/postLogout.ts
+++ b/src/app/(main)/user-info/_lib/postLogout.ts
@@ -10,7 +10,7 @@ const postLogout = async () => {
     throw new Error(SIGNIN_REQUIRED);
   }
 
-  const res = await callFetchWrapper('/api/v1/auth/member/logout', {
+  const res = await callFetchWrapper<any>('/api/v1/auth/member/logout', {
     method: 'post',
     headers: {
       'Content-Type': 'application/json',
@@ -19,15 +19,17 @@ const postLogout = async () => {
     credentials: 'include',
   });
 
-  if (!res.ok && res.error?.message) {
-    if (res.error.code === 1201) {
-      throw new Error(LOGOUT_ERROR_MESSAGE.EXPIRED_TOKEN);
-    } else if (AUTH_MESSAGE.includes(res.error.message)) {
-      throw new Error(res.error.message);
-    }
-
+  if (!res.ok && !res.success) {
     if (!res.error) {
       throw new Error(LOGOUT_ERROR_MESSAGE.UNKNOWN_ERROR);
+    }
+    const errorMessage =
+      typeof res.error.message === 'string' ? res.error.message : 'ERROR';
+
+    if (res.error.code === 1201) {
+      throw new Error(LOGOUT_ERROR_MESSAGE.EXPIRED_TOKEN);
+    } else if (AUTH_MESSAGE.includes(errorMessage)) {
+      throw new Error(errorMessage);
     }
 
     throw new Error(LOGOUT_ERROR_MESSAGE.FAILED_TO_LOGOUT);

--- a/src/app/model/API.ts
+++ b/src/app/model/API.ts
@@ -1,6 +1,6 @@
 export type ApiError = {
   code: number;
-  message: string;
+  message: string | Record<string, string>;
 };
 
 export type ApiErrorResponse = {

--- a/src/app/model/API.ts
+++ b/src/app/model/API.ts
@@ -1,0 +1,22 @@
+export type ApiError = {
+  code: number;
+  message: string;
+};
+
+export type ApiErrorResponse = {
+  success: false;
+  response: null;
+  error: ApiError;
+};
+
+export type ApiSuccessResponse<T> = {
+  success: true;
+  response: T;
+  error: null;
+};
+
+export type ApiResult<T> = {
+  ok: boolean;
+} & ApiResponse<T>;
+
+export type ApiResponse<T> = ApiSuccessResponse<T> | ApiErrorResponse;

--- a/src/app/model/Agora.ts
+++ b/src/app/model/Agora.ts
@@ -9,6 +9,7 @@ export type Status = (typeof AGORA_STATUS)[keyof typeof AGORA_STATUS];
 export type ImageURL = string | null;
 export type AgoraId = number;
 export type AgoraTitle = string;
+export type UserName = string;
 
 export type Participants = {
   pros: number;
@@ -47,7 +48,7 @@ export interface AgoraBasicFacts {
 
 export interface AgoraUserProfileType {
   id: number;
-  nickname: string;
+  nickname: UserName;
   photoNumber: number;
   type: ParticipantPosition;
 }
@@ -106,7 +107,35 @@ export type KickVoteResponse = {
   type: string;
   kickVoteInfo: {
     targetMemberId: number;
-    nickname: string;
+    nickname: UserName;
     message: string;
   };
 };
+
+export type VoteResults = Pick<ClosedAgora, 'id' | 'prosCount' | 'consCount'>;
+export type Vote = {
+  id: number;
+  voteType: ParticipantPosition;
+};
+
+export type ErrorResponse = {
+  code: number;
+  message: string;
+};
+
+export interface AgoraStartResponse {
+  agoraId: AgoraId;
+  startTime: string;
+}
+
+export interface AgoraSearchResponse {
+  next: number | null;
+  hasNext: boolean;
+}
+
+export interface AgoraTitleResponse {
+  title: string;
+  status: Status;
+  imageUrl: ImageURL;
+  agoraColor: string;
+}

--- a/src/app/model/AgoraMeta.ts
+++ b/src/app/model/AgoraMeta.ts
@@ -1,14 +1,14 @@
-import { AgoraId, AgoraTitle, ParticipantPosition } from './Agora';
+import { AgoraId, AgoraTitle, ParticipantPosition, UserName } from './Agora';
 
-type Participants = {
+export type Participants = {
   type: ParticipantPosition;
   count: number;
 };
 
-type AgoraMemberInfo = {
-  agoraId: number;
+export type AgoraMemberInfo = {
+  agoraId: AgoraId;
   memberId: number;
-  username: string;
+  username: UserName;
   socketDisconnectTime: string;
 };
 

--- a/src/app/model/Message.ts
+++ b/src/app/model/Message.ts
@@ -1,16 +1,38 @@
 import { AccessStatus } from './AccessStatus';
+import { ParticipantPosition, UserName } from './Agora';
 import { Reaction } from './Reaction';
 
 export interface Message {
   chatId: number;
   user: {
     id: number;
-    nickname: string;
+    nickname: UserName;
     photoNumber: number;
-    type: string;
+    type: ParticipantPosition | 'ACCESS';
   };
   content: string;
   createdAt: string;
   reactionCount: Reaction;
   access?: AccessStatus;
+}
+
+export interface MessagePageParams {
+  size: string;
+  key?: string;
+}
+
+export interface MessageMetaResponse {
+  key: number | null;
+  effectiveSize: number;
+}
+
+type BadWord = {
+  start: number;
+  end: number;
+  keyword: string;
+};
+
+export interface BadWordsFilterResponse {
+  hasBadWord: boolean;
+  badword: BadWord[];
 }

--- a/src/app/model/ServiceWorker.ts
+++ b/src/app/model/ServiceWorker.ts
@@ -1,0 +1,23 @@
+import { ErrorResponse, Vote, VoteResults } from './Agora';
+
+type VoteSentMessage = {
+  action: 'voteSent';
+  newAccessToken: string;
+  data: Vote;
+};
+
+type VoteResultMessage = {
+  action: 'voteResult';
+  newAccessToken: string;
+  result: VoteResults;
+};
+
+type FetchErrorMessage = {
+  action: 'fetchError';
+  message: ErrorResponse | string;
+};
+
+export type ServiceWorkerMessage =
+  | VoteSentMessage
+  | VoteResultMessage
+  | FetchErrorMessage;

--- a/src/lib/fetchWrapper.ts
+++ b/src/lib/fetchWrapper.ts
@@ -1,3 +1,4 @@
+import { ApiResult } from '@/app/model/API';
 import getKey from '@/utils/getKey';
 import isNull from '@/utils/validation/validateIsNull';
 
@@ -8,7 +9,10 @@ export class FetchWrapper {
     this.#baseURL = (await getKey()).BASE_URL || '';
   }
 
-  static async call(url: string, fetchNext: any): Promise<any> {
+  static async call<T>(
+    url: string,
+    fetchNext: RequestInit,
+  ): Promise<ApiResult<T>> {
     if (isNull(this.#baseURL)) {
       if (isNull(process.env.NEXT_BASE_URL)) {
         await this.setBaseUrl();
@@ -35,6 +39,9 @@ export class FetchWrapper {
 }
 
 // 서버 컴포넌트는 aysnc 함수를 export 해야한다.
-export async function callFetchWrapper(url: string, fetchNext: any) {
-  return FetchWrapper.call(url, fetchNext);
+export async function callFetchWrapper<T>(
+  url: string,
+  fetchNext: RequestInit,
+): Promise<ApiResult<T>> {
+  return FetchWrapper.call<T>(url, fetchNext);
 }

--- a/src/lib/getAgoras.ts
+++ b/src/lib/getAgoras.ts
@@ -1,11 +1,20 @@
+import { AgoraId } from '@/app/model/Agora';
+import isNull from '@/utils/validation/validateIsNull';
 import { callFetchWrapper } from './fetchWrapper';
+
+type AgoraIdsResponse = {
+  id: AgoraId[];
+};
 
 // eslint-disable-next-line import/prefer-default-export
 export const getAgoraList = async () => {
-  const res = await callFetchWrapper('/api/v1/open/agoras/ids', {
-    method: 'get',
-    credentials: 'include',
-  });
+  const res = await callFetchWrapper<AgoraIdsResponse>(
+    '/api/v1/open/agoras/ids',
+    {
+      method: 'get',
+      credentials: 'include',
+    },
+  );
 
   if (!res.ok && !res.success) {
     if (res.error.code === 1301) {
@@ -13,6 +22,10 @@ export const getAgoraList = async () => {
       return [];
     }
 
+    return [];
+  }
+
+  if (isNull(res.response)) {
     return [];
   }
 

--- a/src/lib/getReissuanceToken.ts
+++ b/src/lib/getReissuanceToken.ts
@@ -1,15 +1,22 @@
 import { callFetchWrapper } from './fetchWrapper';
 
+type ReissuanceTokenResponse = {
+  accessToken: string;
+};
+
 export const getReissuanceToken = async (token: string) => {
-  const res = await callFetchWrapper('/api/v1/auth/reissue', {
-    method: 'POST',
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
+  const res = await callFetchWrapper<ReissuanceTokenResponse>(
+    '/api/v1/auth/reissue',
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'Cache-Control': 'no-cache',
+      },
     },
-    'Cache-Control': 'no-cache',
-  });
+  );
 
   if (!res.ok && !res.success) {
     // 토큰 재발급 실패


### PR DESCRIPTION
### 🔗 Linked Issue

- [ ] #214 

### 🛠 개발 기능

- API 응답의 response 값의 타입을 동적으로 넣어주도록 제네릭 선언
- model 공통 타입 중 추가로 좁힐 수 있는 타입 재정의
- _lib 폴더 파일들 response 타입에 맞춰 타입 선언

### 🧩 해결 방법

- API 응답 response 타입을 선언해두면 해당 응답값을 사용하는 파일에서 자동 검색이 가능합니다.
- 그렇기에 _lib 폴더 등 서버 응답에 관한 파일의 타입을 좁혀 사용하고자 하여 `fetchWrapper` 파일에 제네릭을 선언하였습니다.

### 🔍 리뷰 포인트

- (chat)의 _lib 폴더에 정의한 응답 타입들을 참고하셔서 어떻게 타입을 전달해줘야 하는지 확인해주세요.
- 수정되어야 하는 타입/파일이 있다면 코멘트 달아주세요.

### 전달사항
- (main) 폴더의 하위 _lib 폴더, (main)/user-info 하위 _lib 폴더 파일 등 (main) 하위에 존재하는 API 관련 파일을 살펴서 응답 타입을 좁혀주세요.

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
