### PR TITLE
Refactor/main logic separation

### DIFF
--- a/src/app/(main)/_lib/postCreateAgora.ts
+++ b/src/app/(main)/_lib/postCreateAgora.ts
@@ -1,4 +1,4 @@
-import { AgoraConfig, AgoraId } from '@/app/model/Agora';
+import { AgoraConfig, CreateAgoraResponse } from '@/app/model/Agora';
 import { callFetchWrapper } from '@/lib/fetchWrapper';
 import { getSession } from '@/serverActions/auth';
 import { AUTH_MESSAGE, SIGNIN_REQUIRED } from '@/constants/authErrorMessage';
@@ -15,10 +15,6 @@ const CAPACITY_NULL = { categoryId: '널이어서는 안됩니다' };
 const DURATION_UNDER_ERROR = { duration: '1 이상이어야 합니다' };
 const DURATION_OVER_ERROR = { duration: '180 이하이어야 합니다' };
 const FILE_SIZE_OVER_ERROR = 'File size cannot exceed 5MB.';
-
-type CreateAgoraResponse = {
-  id: AgoraId;
-};
 
 export const postCreateAgora = async (
   info: AgoraConfig,

--- a/src/app/(main)/create-agora/_component/AgoraTitleInput.tsx
+++ b/src/app/(main)/create-agora/_component/AgoraTitleInput.tsx
@@ -1,14 +1,11 @@
 'use client';
 
 import { useCreateAgora } from '@/store/create';
-import { useRouter } from 'next/navigation';
 import React, { ChangeEventHandler, useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
 export default function AgoraTitleInput() {
   const [message, setMessage] = useState<string | null>('주제를 입력해주세요.');
-  const router = useRouter();
-
   const { title, setTitle } = useCreateAgora(
     useShallow((state) => ({
       title: state.title,
@@ -30,14 +27,12 @@ export default function AgoraTitleInput() {
     }
   };
 
-  const dataReset = () => {
-    setTitle('');
-    setMessage(null);
-  };
-
   useEffect(() => {
-    dataReset();
-  }, [router]);
+    return () => {
+      setTitle('');
+      setMessage(null);
+    };
+  }, []);
 
   return (
     <>

--- a/src/app/(main)/create-agora/_component/AgoraTitleInput.tsx
+++ b/src/app/(main)/create-agora/_component/AgoraTitleInput.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useCreateAgora } from '@/store/create';
-import { useSearchStore } from '@/store/search';
 import { useRouter } from 'next/navigation';
 import React, { ChangeEventHandler, useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
@@ -9,11 +8,6 @@ import { useShallow } from 'zustand/react/shallow';
 export default function AgoraTitleInput() {
   const [message, setMessage] = useState<string | null>('주제를 입력해주세요.');
   const router = useRouter();
-  const { reset } = useSearchStore(
-    useShallow((state) => ({
-      reset: state.reset,
-    })),
-  );
 
   const { title, setTitle } = useCreateAgora(
     useShallow((state) => ({
@@ -39,7 +33,6 @@ export default function AgoraTitleInput() {
   const dataReset = () => {
     setTitle('');
     setMessage(null);
-    reset();
   };
 
   useEffect(() => {

--- a/src/app/(main)/create-agora/_component/CreateAgoraBtn.tsx
+++ b/src/app/(main)/create-agora/_component/CreateAgoraBtn.tsx
@@ -1,120 +1,45 @@
 'use client';
 
-import {
-  QueryClient,
-  UseMutateFunction,
-  useMutation,
-  useQueryClient,
-} from '@tanstack/react-query';
-import React, { KeyboardEventHandler, useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import React, { KeyboardEventHandler, useCallback, useEffect } from 'react';
 import { useCreateAgora } from '@/store/create';
 import { useRouter } from 'next/navigation';
-import { useAgora } from '@/store/agora';
 import Loading from '@/app/_components/atoms/loading';
 import showToast from '@/utils/showToast';
-import { AgoraConfig } from '@/app/model/Agora';
-import { enterAgoraSegmentKey } from '@/constants/segmentKey';
-import { AGORA_CREATE, AGORA_STATUS } from '@/constants/agora';
-import useApiError from '@/hooks/useApiError';
-import { COLOR } from '@/constants/consts';
 import { useShallow } from 'zustand/react/shallow';
 import { useUploadImage } from '@/store/uploadImage';
-import { useSearchStore } from '@/store/search';
-import isNull from '@/utils/validation/validateIsNull';
-import { postCreateAgora } from '../../_lib/postCreateAgora';
+import { validateCreateAgora } from '@/utils/validation/validateCreateAgora';
+import { useCreateAgoraAction } from '@/hooks/useCreateAgoraAction';
 
 function CreateAgoraBtn() {
-  const [createAgora, setCreateAgora] = useState<AgoraConfig>({
-    title: '',
-    imageUrl: '',
-    category: '1',
-    color: { idx: 0, value: COLOR[0].value },
-    capacity: 5,
-    duration: 60,
-  });
   const router = useRouter();
-  const [isLoading, setIsLoading] = useState<boolean>(false);
   const queryClient = useQueryClient();
-  const { handleError } = useApiError();
-  const { reset: searchReset } = useSearchStore.getState();
-  const { reset } = useCreateAgora(
-    useShallow((state) => ({
-      reset: state.reset,
-    })),
+
+  const routeAgoraPage = useCallback(
+    (path: string) => {
+      router.push(path);
+    },
+    [router],
   );
+
   const { resetUploadImageState } = useUploadImage(
     useShallow((state) => ({
       resetUploadImageState: state.resetUploadImageState,
     })),
   );
-  const { setSelectedAgora } = useAgora(
-    useShallow((state) => ({
-      setSelectedAgora: state.setSelectedAgora,
-    })),
-  );
 
-  const invalidAgora = async (client: QueryClient, queryKey: string[]) => {
-    await client.invalidateQueries({ queryKey });
-  };
-
-  const failedCreateAgora = async (
-    error: Error,
-    mutation: UseMutateFunction<any, Error, void, unknown>,
-  ) => {
-    setIsLoading(false);
-    await handleError(error, mutation);
-  };
-
-  const mutation = useMutation({
-    mutationFn: async () => {
-      const info = {
-        ...createAgora,
-      };
-      return postCreateAgora(info);
-    },
-    onSuccess: async (response) => {
-      reset();
-      searchReset();
-      resetUploadImageState();
-
-      if (!isNull(response)) {
-        setSelectedAgora({
-          id: response.id,
-          imageUrl: createAgora.imageUrl,
-          agoraTitle: createAgora.title,
-          status: AGORA_STATUS.QUEUED,
-          agoraColor: createAgora.color.value,
-        });
-
-        setIsLoading(false);
-
-        await invalidAgora(queryClient, ['agora']);
-        router.push(`/flow${enterAgoraSegmentKey}/${response.id}`);
-        return;
-      }
-      await failedCreateAgora(
-        new Error('아고라 생성에 실패했습니다.'),
-        mutation.mutate,
-      );
-    },
-    onError: async (error) => {
-      await failedCreateAgora(error, mutation.mutate);
-    },
-  });
+  const { isLoading, createAgoraMutation, setCreateAgora } =
+    useCreateAgoraAction({
+      routeAgoraPage,
+      queryClient,
+      resetUploadImageState,
+    });
 
   const handleClick = () => {
     const { title, imageUrl, category, color, capacity, duration } =
       useCreateAgora.getState();
 
-    if (
-      title.trim() === '' ||
-      title.length > 15 ||
-      !color ||
-      !category ||
-      !duration ||
-      duration > AGORA_CREATE.MAX_DISCUSSION_TIME ||
-      duration < AGORA_CREATE.MIN_DISCUSSION_TIME
-    ) {
+    if (validateCreateAgora({ title, color, category, duration })) {
       showToast('입력값을 확인해주세요.', 'error');
       return;
     }
@@ -128,8 +53,7 @@ function CreateAgoraBtn() {
       duration,
     });
 
-    setIsLoading(true);
-    mutation.mutate();
+    createAgoraMutation.mutate();
   };
 
   const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = (e) => {

--- a/src/app/(main)/create-agora/_component/CreateAgoraBtn.tsx
+++ b/src/app/(main)/create-agora/_component/CreateAgoraBtn.tsx
@@ -36,6 +36,7 @@ function CreateAgoraBtn() {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const queryClient = useQueryClient();
   const { handleError } = useApiError();
+  const { reset: searchReset } = useSearchStore.getState();
   const { reset } = useCreateAgora(
     useShallow((state) => ({
       reset: state.reset,
@@ -73,6 +74,7 @@ function CreateAgoraBtn() {
     },
     onSuccess: async (response) => {
       reset();
+      searchReset();
       resetUploadImageState();
 
       if (!isNull(response)) {
@@ -139,10 +141,8 @@ function CreateAgoraBtn() {
   useEffect(() => {
     return () => {
       const { reset: createStoreReset } = useCreateAgora.getState();
-      const { reset: searchReset } = useSearchStore.getState();
 
       createStoreReset(); // 언마운트시 초기
-      searchReset();
       resetUploadImageState();
     };
   }, []);

--- a/src/app/(main)/login/auth/components/AuthLogin.tsx
+++ b/src/app/(main)/login/auth/components/AuthLogin.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import Loading from '@/app/_components/atoms/loading';
-import showToast from '@/utils/showToast';
-import { signInWithCredentials } from '@/serverActions/auth';
-import { signIn, useSession } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import React, { useCallback, useEffect, useLayoutEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import isNull from '@/utils/validation/validateIsNull';
 import { homeSegmentKey } from '@/constants/segmentKey';
+import { useGetAccessTokenAction } from '@/hooks/useGetAccessTokenAction';
 
 type Props = {
   user: string;
@@ -18,39 +17,20 @@ export default function AuthLogin({ user, callbackUrl }: Props) {
   const router = useRouter();
   const { data: session } = useSession();
 
-  const getUserAccessToken = useCallback(
-    async (authuser: string) => {
-      const tempToken = await signInWithCredentials(authuser);
-
-      if (tempToken.success) {
-        try {
-          await signIn('credentials', {
-            accessToken: tempToken.accessToken,
-          });
-        } catch (error) {
-          showToast('로그인에 실패했습니다. 다시 시도해주세요.', 'error');
-          router.replace('/');
-        }
-      } else if (!tempToken.success) {
-        showToast('로그인에 실패했습니다. 다시 시도해주세요.', 'error');
-        router.replace('/');
-      }
+  const routeAgoraPage = useCallback(
+    (path: string) => {
+      router.replace(path);
     },
     [router],
   );
 
+  useGetAccessTokenAction({ routeAgoraPage, user });
+
   useEffect(() => {
     if (!isNull(callbackUrl) && !isNull(session)) {
-      router.replace(homeSegmentKey);
+      routeAgoraPage(homeSegmentKey);
     }
-  }, [router, session]);
-
-  useLayoutEffect(() => {
-    if (isNull(user)) {
-      return;
-    }
-    getUserAccessToken(user);
-  }, [getUserAccessToken, user]);
+  }, [routeAgoraPage, session]);
 
   return (
     <div className="min-w-300 w-full h-full flex absolute justify-center items-center z-20 top-0 right-0 left-0 bottom-0 bg-opacity-50 bg-dark-bg-dark">

--- a/src/app/model/Agora.ts
+++ b/src/app/model/Agora.ts
@@ -158,3 +158,7 @@ export interface EnterClosedAgoraResponse {
   agoraId: AgoraId;
   memberId: number;
 }
+
+export interface CreateAgoraResponse {
+  id: AgoraId;
+}

--- a/src/hooks/query/useCreateAgoraMutation.ts
+++ b/src/hooks/query/useCreateAgoraMutation.ts
@@ -1,0 +1,18 @@
+import { postCreateAgora } from '@/app/(main)/_lib/postCreateAgora';
+import { AgoraConfig, CreateAgoraResponse } from '@/app/model/Agora';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+
+type CreateAgoraMutationArg = {
+  agoraInfo: AgoraConfig;
+  options: UseMutationOptions<CreateAgoraResponse, Error>;
+};
+
+export const useCreateAgoraMutation = ({
+  agoraInfo,
+  options,
+}: CreateAgoraMutationArg) => {
+  return useMutation({
+    mutationFn: () => postCreateAgora(agoraInfo),
+    ...options,
+  });
+};

--- a/src/hooks/useCategoryStatus.ts
+++ b/src/hooks/useCategoryStatus.ts
@@ -4,13 +4,12 @@ import { useCreateAgora } from '@/store/create';
 import { useSearchStore } from '@/store/search';
 import { isValidCategoryKey } from '@/utils/validation/validateCategoryKey';
 import isNull from '@/utils/validation/validateIsNull';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useEffect } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
 export const useCategoryStatus = () => {
   const pathname = usePathname();
-  const router = useRouter();
   const searchParams = useSearchParams();
   const { reset } = useSearchStore(
     useShallow((state) => ({
@@ -44,8 +43,8 @@ export const useCategoryStatus = () => {
     };
   }, []);
 
-  const changeCategoryParams = useCallback(
-    (id: string) => {
+  useEffect(() => {
+    const changeCategoryParams = (id: string) => {
       if (pathname !== homeSegmentKey) return;
 
       const newSearchParams = new URLSearchParams(searchParams);
@@ -60,13 +59,10 @@ export const useCategoryStatus = () => {
         '',
         newUrl,
       );
-    },
-    [router, searchParams, pathname, selectedCategory],
-  );
+    };
 
-  useEffect(() => {
     changeCategoryParams(selectedCategory);
-  }, [selectedCategory, changeCategoryParams]);
+  }, [selectedCategory]);
 
   return {
     setCategory,

--- a/src/hooks/useCreateAgoraAction.ts
+++ b/src/hooks/useCreateAgoraAction.ts
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { AgoraConfig } from '@/app/model/Agora';
+import { useSearchStore } from '@/store/search';
+import { useCreateAgora } from '@/store/create';
+import { useShallow } from 'zustand/react/shallow';
+import { useAgora } from '@/store/agora';
+import { QueryClient, UseMutateFunction } from '@tanstack/react-query';
+import { enterAgoraSegmentKey } from '@/constants/segmentKey';
+import { AGORA_STATUS } from '@/constants/agora';
+import { COLOR } from '@/constants/consts';
+import { useCreateAgoraMutation } from './query/useCreateAgoraMutation';
+import useApiError from './useApiError';
+
+type CreateAgoraActionArg = {
+  routeAgoraPage: (path: string) => void;
+  queryClient: QueryClient;
+  resetUploadImageState: () => void;
+};
+
+export const useCreateAgoraAction = ({
+  routeAgoraPage,
+  queryClient,
+  resetUploadImageState,
+}: CreateAgoraActionArg) => {
+  const { handleError } = useApiError();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [createAgora, setCreateAgora] = useState<AgoraConfig>({
+    title: '',
+    imageUrl: '',
+    category: '1',
+    color: { idx: 0, value: COLOR[0].value },
+    capacity: 5,
+    duration: 60,
+  });
+  const { reset: searchReset } = useSearchStore(
+    useShallow((state) => ({
+      reset: state.reset,
+    })),
+  );
+  const { reset } = useCreateAgora(
+    useShallow((state) => ({
+      reset: state.reset,
+    })),
+  );
+  const { setSelectedAgora } = useAgora(
+    useShallow((state) => ({
+      setSelectedAgora: state.setSelectedAgora,
+    })),
+  );
+
+  const failedCreateAgora = async (
+    error: Error,
+    mutation: UseMutateFunction<any, Error, void, unknown>,
+  ) => {
+    setIsLoading(false);
+    await handleError(error, mutation);
+  };
+
+  const mutation = useCreateAgoraMutation({
+    agoraInfo: { ...createAgora },
+    options: {
+      onMutate: () => {
+        setIsLoading(true);
+      },
+      onSuccess: async (response) => {
+        reset();
+        searchReset();
+        resetUploadImageState();
+
+        if (!isNull(response)) {
+          setSelectedAgora({
+            id: response.id,
+            imageUrl: createAgora.imageUrl,
+            agoraTitle: createAgora.title,
+            status: AGORA_STATUS.QUEUED,
+            agoraColor: createAgora.color.value,
+          });
+
+          setIsLoading(false);
+
+          await queryClient.invalidateQueries({ queryKey: ['agora'] });
+          routeAgoraPage(`/flow${enterAgoraSegmentKey}/${response.id}`);
+          return;
+        }
+
+        // 요청은 성공했지만 정상적인 응답이 오지 않는다면 실패로 간주
+        await failedCreateAgora(
+          new Error('아고라 생성에 실패했습니다.'),
+          mutation.mutate,
+        );
+      },
+      onError: async (error) => {
+        await failedCreateAgora(error, mutation.mutate);
+      },
+    },
+  });
+
+  return {
+    isLoading,
+    createAgoraMutation: mutation,
+    setCreateAgora,
+  };
+};

--- a/src/hooks/useGetAccessTokenAction.ts
+++ b/src/hooks/useGetAccessTokenAction.ts
@@ -1,0 +1,44 @@
+import { useCallback, useLayoutEffect } from 'react';
+import showToast from '@/utils/showToast';
+import { signInWithCredentials } from '@/serverActions/auth';
+import { signIn } from 'next-auth/react';
+import isNull from '@/utils/validation/validateIsNull';
+
+type GetAccessTokenActionArg = {
+  routeAgoraPage: (path: string) => void;
+  user: string;
+};
+
+export const useGetAccessTokenAction = ({
+  routeAgoraPage,
+  user,
+}: GetAccessTokenActionArg) => {
+  const getUserAccessToken = useCallback(
+    async (authuser: string) => {
+      const tempToken = await signInWithCredentials(authuser);
+
+      if (tempToken.success) {
+        try {
+          await signIn('credentials', {
+            accessToken: tempToken.accessToken,
+          });
+        } catch (error) {
+          showToast('로그인에 실패했습니다. 다시 시도해주세요.', 'error');
+          routeAgoraPage('/');
+        }
+      } else if (!tempToken.success) {
+        showToast('로그인에 실패했습니다. 다시 시도해주세요.', 'error');
+        routeAgoraPage('/');
+      }
+    },
+    [routeAgoraPage],
+  );
+
+  useLayoutEffect(() => {
+    if (isNull(user)) {
+      return;
+    }
+
+    getUserAccessToken(user);
+  }, [getUserAccessToken, user]);
+};

--- a/src/utils/validation/validateCreateAgora.ts
+++ b/src/utils/validation/validateCreateAgora.ts
@@ -1,0 +1,24 @@
+import { AgoraConfig } from '@/app/model/Agora';
+import { AGORA_CREATE } from '@/constants/agora';
+
+type ValidateCreateAgoraArg = Omit<AgoraConfig, 'imageUrl' | 'capacity'>;
+
+export const validateCreateAgora = ({
+  title,
+  color,
+  category,
+  duration,
+}: ValidateCreateAgoraArg) => {
+  if (
+    title.trim() === '' ||
+    title.length > 15 ||
+    !color ||
+    !category ||
+    !duration ||
+    duration > AGORA_CREATE.MAX_DISCUSSION_TIME ||
+    duration < AGORA_CREATE.MIN_DISCUSSION_TIME
+  ) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
### 🔗 Linked Issue

- [ ] #117 

### 🛠 개발 기능

- 아고라 입장 모달 비즈니스 로직 분리
- 아고라 생성 페이지와 홈 사이 연결된 버그 수정
  - 홈에서 키워드 입력, 엔터 후 생성 페이지로 넘어왔다 돌아가면 서치 기능은 동작하지 않은채 키워드만 남는 문제
- 로그인 페이지 Access Token 호출 및 저장 로직 분리

### 🧩 해결 방법

- 홈으로 이동시 `search` 전역 상태가 reset 되면서 발생하는 문제로, 불필요한 reset이 발생하지 않도록 수정

### 🔍 리뷰 포인트

- 

<br>

---

### 📋 Code Review Priority Guideline

- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
